### PR TITLE
Fix partial borrow compilation error

### DIFF
--- a/src/omni-ledger/src/storage.rs
+++ b/src/omni-ledger/src/storage.rs
@@ -203,7 +203,7 @@ impl LedgerStorage {
         self.persistent_store
             .apply(&[
                 (
-                    key_for_transaction(transaction.id),
+                    key_for_transaction(transaction.id.clone()),
                     fmerk::Op::Put(minicbor::to_vec(&transaction).unwrap()),
                 ),
                 (


### PR DESCRIPTION
`omni-ledger` master is broken since the Clippy and TransactionId changes. This PR fixes it.


TransactionId is not Copyable.