### PR TITLE
Add security audit to CICD

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,5 @@
 name: Security audit
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
This PR will perform a security check of our dependencies every day at midnight on the HEAD of the main branch. An issue is supposed to be automatically created for each vulnerability found but I couldn't test this from the branch.

You should also be able to trigger this workflow manually.

We already found multiple vulnerabilities

https://rustsec.org/advisories/RUSTSEC-2020-0159
https://rustsec.org/advisories/RUSTSEC-2020-0036
https://rustsec.org/advisories/RUSTSEC-2020-0071

Most are coming from the `fmerk` crate.

Fixes #33 