### PR TITLE
Refactor and improve the run.sh script

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -31,6 +31,7 @@ verlt() {
 check_dep() {
     which "$1" >/dev/null || {
         echo You need the binary \""$1"\" installed and accessible to use this script.
+        echo
         false
     }
 }
@@ -39,6 +40,7 @@ check_deps() {
     local return_value
     return_value=0
     check_dep tmux || return_value=$((return_value + 1))
+    check_dep ssh-keygen || return_value=$((return_value + 1))
 
     # Check that tendermint is installed AND that it has the minimum version.
     if ! command -v tendermint >/dev/null; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -56,20 +56,6 @@ check_deps() {
         }
     fi
 
-    # Check that openssl is installed and support the right algorithm.
-    if ! command -v openssl >/dev/null; then
-        echo OpenSSL is not installed or could not be found.
-        echo Please installed it using your platforms package manager.
-        return_value=$((return_value + 1))
-    else
-        if ! command -v openssl genpkey -algorithm Ed25519 >/dev/null; then
-            echo OpenSSL does not support generating Ed25519 keys.
-            echo You should have at least version 3.0.2.
-            echo This is a typical problem with MacOS. Install openssl using homebrew to fix.
-            return_value=$((return_value + 1))
-        fi
-    fi
-
     return $return_value
 }
 
@@ -101,7 +87,7 @@ main() {
         # Create 5 keys in the root.
         mkdir -p "$pem_root"
         for fn in "$pem_root"/id{1,2,3,4,5}.pem; do
-            openssl genpkey -algorithm Ed25519 >"$fn"
+            ssh-keygen -a 100 -q -P "" -m pkcs8 -t ecdsa -f "$fn"
         done
     }
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -124,6 +124,8 @@ main() {
 
     tmux new-session -s "$tmux_name" -n tendermint-ledger -d "TMHOME=\"$root_dir/ledger\" tendermint start 2>&1 | tee \"$root_dir/tendermint-ledger.log\""
     tmux new-window -t "$tmux_name" -n tendermint-kvstore "TMHOME=\"$root_dir/kvstore\" tendermint start 2>&1 | tee \"$root_dir/tendermint-kvstore.log\""
+    # This makes sure the sessions remain opened when the command exits.
+    tmux setw remain-on-exit on
 
     tmux new-window -t "$tmux_name" -n ledger -e SHELL=bash "./target/debug/many-ledger -v -v --abci --addr 127.0.0.1:8001 --pem \"$pem_root/id1.pem\" --state ./staging/ledger_state.json5 --persistent \"$root_dir/ledger.db\" 2>&1 | tee \"$root_dir/many-ledger.log\""
     tmux new-window -t "$tmux_name" -n ledger-abci "./target/debug/many-abci -v -v --many 127.0.0.1:8000 --many-app http://localhost:8001 --many-pem \"$pem_root/id2.pem\" --abci 127.0.0.1:26658 --tendermint http://localhost:26657/ 2>&1 | tee \"$root_dir/many-abci-ledger.log\""

--- a/src/many-abci/src/main.rs
+++ b/src/many-abci/src/main.rs
@@ -176,6 +176,7 @@ async fn main() {
     }
 
     let key = CoseKeyIdentity::from_pem(&std::fs::read_to_string(&many_pem).unwrap()).unwrap();
+    info!(many_address = key.identity.to_string().as_str());
     let server = ManyServer::new(
         format!("AbciModule({})", &status.name),
         key.clone(),

--- a/src/many-ledger/src/main.rs
+++ b/src/many-ledger/src/main.rs
@@ -148,6 +148,7 @@ fn main() {
 
     let pem = std::fs::read_to_string(&pem).expect("Could not read PEM file.");
     let key = CoseKeyIdentity::from_pem(&pem).expect("Could not generate identity from PEM file.");
+    tracing::info!(address = key.identity.to_string().as_str());
 
     let state: Option<InitialStateJson> =
         state.map(|p| InitialStateJson::read(p).expect("Could not read state file."));


### PR DESCRIPTION
- No longer requires a PEM file at a specific directory (instead creates pem files before running tmux).
- No longer requires Ed25519 support for OpenSSL. If you have an old version of OpenSSL this fixes it.
- Keep the tmux windows open when the command fails.
- Ran a formatter on the bash code (about time)
- Check that openssl supports the right algorithm prior to running, showing an error message that at least have some semblance of steps for users to take.
- Some shellchecks being fixed. I suggest we do use shellcheck at some point but that's outside the scope of this (I just have it as my linter for bash files in my IDE).
- Move global variables to global section and add local to local variables.