### PR TITLE
Catch-up BATs test and maintenance

### DIFF
--- a/docker/e2e/Makefile
+++ b/docker/e2e/Makefile
@@ -81,10 +81,15 @@ start-docker-compose: start-nodes
 start-nodes-background: genfiles/build-abci genfiles/build-ledger genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e up --detach
 
-start-node-background: genfiles/build-abci genfiles/build-ledger genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
+start-single-node-background: genfiles/build-abci genfiles/build-ledger genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e up --detach tendermint-$(NODE)
 	docker-compose -f genfiles/docker-compose.json -p e2e up --detach abci-$(NODE)
 	docker-compose -f genfiles/docker-compose.json -p e2e up --detach ledger-$(NODE)
+
+stop-single-node-background:
+	docker-compose -f genfiles/docker-compose.json -p e2e down tendermint-$(NODE)
+	docker-compose -f genfiles/docker-compose.json -p e2e down abci-$(NODE)
+	docker-compose -f genfiles/docker-compose.json -p e2e down ledger-$(NODE)
 
 chaos:
 	sh chaos.sh

--- a/docker/e2e/Makefile
+++ b/docker/e2e/Makefile
@@ -54,7 +54,7 @@ genfiles/node%: genfiles/openssl-docker
 	docker run --user $$(id -u) -it --rm -v ${PWD}/$@/:/export alpine/openssl genpkey -algorithm Ed25519 -out /export/ledger.pem
 	docker run --user $$(id -u) -it --rm -v ${PWD}/$@/:/export alpine/openssl genpkey -algorithm Ed25519 -out /export/abci.pem
 	mkdir -p "$@/persistent-ledger"
-	cp ledger_state.json5 $@/ledger_state.json5
+	cp ledger_state.json $@/ledger_state.json5
 
 
 genfiles/generate-tendermint-e2e-config:
@@ -80,6 +80,11 @@ start-docker-compose: start-nodes
 
 start-nodes-background: genfiles/build-abci genfiles/build-ledger genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e up --detach
+
+start-node-background: genfiles/build-abci genfiles/build-ledger genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
+	docker-compose -f genfiles/docker-compose.json -p e2e up --detach tendermint-$(NODE)
+	docker-compose -f genfiles/docker-compose.json -p e2e up --detach abci-$(NODE)
+	docker-compose -f genfiles/docker-compose.json -p e2e up --detach ledger-$(NODE)
 
 chaos:
 	sh chaos.sh

--- a/docker/e2e/docker-compose.jsonnet
+++ b/docker/e2e/docker-compose.jsonnet
@@ -43,7 +43,7 @@ local ledger(i, user, id_with_balances) = {
     ] + generate_balance_flags(id_with_balances),
 };
 
-local tendermint(i, user, tendermint_tag="v0.35.1") = {
+local tendermint(i, user, tendermint_tag="v0.35.4") = {
     image: "tendermint/tendermint:" + tendermint_tag,
     command: [
         "--log-level", "info",

--- a/docker/e2e/ledger_state.json
+++ b/docker/e2e/ledger_state.json
@@ -8,5 +8,5 @@
   "symbols": {
     "mqbfbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wiaaaaqnz": "MFX"
   },
-  "hash": "358d9e17620ce70180aa131ba32b71ca2ccefe26f619717a4b16f04ea4c9f8f9"
+  "hash": "2f136dfbb7bf5c2178297c8b6486162aeaf9555046a56b5f45995fec83639618"
 }

--- a/tests/resiliency/catch-up.bats
+++ b/tests/resiliency/catch-up.bats
@@ -10,7 +10,7 @@ function setup() {
       make clean
       for i in {0..2}
       do
-          make start-node-background ID_WITH_BALANCES="$(identity 1):1000000" NODE="${i}" || {
+          make start-single-node-background ID_WITH_BALANCES="$(identity 1):1000000" NODE="${i}" || {
             echo Could not start nodes... >&3
             exit 1
           }
@@ -87,7 +87,7 @@ function check_consistency() {
     cd "$GIT_ROOT/docker/e2e/" || exit 1
 
     # At this point, start the 4th node and check it can catch up
-    make start-node-background ID_WITH_BALANCES="$(identity 1):1000000" NODE="3" || {
+    make start-single-node-background ID_WITH_BALANCES="$(identity 1):1000000" NODE="3" || {
       echo Could not start nodes... >&3
       exit 1
     }
@@ -104,3 +104,39 @@ EOT
     check_consistency "$(pem 2)" 10000 0 1 2 3
 }
 
+@test "$SUITE: Node can catch up messages older than MANY timeout" {
+    # Check consistency with nodes [0, 2] up
+    check_consistency "$(pem 1)" 1000000 0 1 2
+    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    sleep 4  # One consensus round.
+    check_consistency "$(pem 1)" 999000 0 1 2
+    check_consistency "$(pem 2)" 1000 0 1 2
+
+    ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
+    ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
+    sleep 4  # One consensus round.
+    check_consistency "$(pem 1)" 997000 0 1 2
+    check_consistency "$(pem 2)" 3000 0 1 2
+
+    cd "$GIT_ROOT/docker/e2e/" || exit 1
+
+    # MANY timeout is 300
+    sleep 301
+
+    # At this point, start the 4th node and check it can catch up
+    make start-single-node-background ID_WITH_BALANCES="$(identity 1):1000000" NODE="3" || {
+      echo Could not start nodes... >&3
+      exit 1
+    }
+
+    # Give the 4th node some time to boot
+    sleep 30
+    timeout 30s bash <<EOT
+    while ! many message --server http://localhost:8003 status; do
+      sleep 1
+    done >/dev/null
+EOT
+    sleep 12  # Three consensus round.
+    check_consistency "$(pem 1)" 997000 0 1 2 3
+    check_consistency "$(pem 2)" 3000 0 1 2 3
+}

--- a/tests/resiliency/catch-up.bats
+++ b/tests/resiliency/catch-up.bats
@@ -1,0 +1,106 @@
+GIT_ROOT="$BATS_TEST_DIRNAME/../../"
+
+load '../test_helper/load'
+
+function setup() {
+    mkdir "$BATS_TEST_ROOTDIR"
+
+    (
+      cd "$GIT_ROOT/docker/e2e/" || exit
+      make clean
+      for i in {0..2}
+      do
+          make start-node-background ID_WITH_BALANCES="$(identity 1):1000000" NODE="${i}" || {
+            echo Could not start nodes... >&3
+            exit 1
+          }
+      done
+    ) > /dev/null
+    (
+      cd "$GIT_ROOT" || exit 1
+      cargo build --all-features
+    )
+
+    # Give time to the servers to start.
+    sleep 30
+    timeout 30s bash <<EOT
+    while ! many message --server http://localhost:8000 status; do
+      sleep 1
+    done >/dev/null
+EOT
+}
+
+function teardown() {
+    (
+      cd "$GIT_ROOT/docker/e2e/" || exit 1
+      make stop-nodes
+    ) 2> /dev/null
+}
+
+function ledger() {
+    local pem="$1"
+    local port="$2"
+    shift 2
+    run "$GIT_ROOT/target/debug/ledger" --pem "$pem" "http://localhost:$((port + 8000))/" "$@"
+}
+
+function check_consistency() {
+    local pem="$1"
+    local expected_balance="$2"
+    shift 2
+
+    for port in "$@"; do
+        ledger "$pem" "$port" balance
+        assert_output --partial " $expected_balance MFX "
+    done
+}
+
+@test "$SUITE: Node can catch up" {
+    # Check consistency with nodes [0, 2] up
+    check_consistency "$(pem 1)" 1000000 0 1 2
+    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    sleep 4  # One consensus round.
+    check_consistency "$(pem 1)" 999000 0 1 2
+    check_consistency "$(pem 2)" 1000 0 1 2
+
+    ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
+    ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
+    sleep 4  # One consensus round.
+    check_consistency "$(pem 1)" 997000 0 1 2
+    check_consistency "$(pem 2)" 3000 0 1 2
+
+    ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
+    ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
+    ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
+    sleep 4  # One consensus round.
+    check_consistency "$(pem 1)" 994000 0 1 2
+    check_consistency "$(pem 2)" 6000 0 1 2
+
+    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    sleep 4  # One consensus round.
+    check_consistency "$(pem 1)" 990000 0 1 2
+    check_consistency "$(pem 2)" 10000 0 1 2
+
+    cd "$GIT_ROOT/docker/e2e/" || exit 1
+
+    # At this point, start the 4th node and check it can catch up
+    make start-node-background ID_WITH_BALANCES="$(identity 1):1000000" NODE="3" || {
+      echo Could not start nodes... >&3
+      exit 1
+    }
+
+    # Give the 4th node some time to boot
+    sleep 30
+    timeout 30s bash <<EOT
+    while ! many message --server http://localhost:8003 status; do
+      sleep 1
+    done >/dev/null
+EOT
+    sleep 12  # Three consensus round.
+    check_consistency "$(pem 1)" 990000 0 1 2 3
+    check_consistency "$(pem 2)" 10000 0 1 2 3
+}
+

--- a/tests/resiliency/up-down.bats
+++ b/tests/resiliency/up-down.bats
@@ -15,11 +15,11 @@ function setup() {
     ) > /dev/null
     (
       cd "$GIT_ROOT" || exit 1
-      cargo build
+      cargo build --all-features
     )
 
     # Give time to the servers to start.
-    sleep 1
+    sleep 30
     timeout 30s bash <<EOT
     while ! many message --server http://localhost:8000 status; do
       sleep 1
@@ -78,7 +78,7 @@ function check_consistency() {
 
 @test "$SUITE: Network is consistent with 1 node down" {
     # Bring down node 3.
-    docker stop e2e_tendermint-3_1
+    docker stop e2e-tendermint-3-1
 
     # Check consistency with all nodes up.
     check_consistency "$(pem 1)" 1000000 0 1 2
@@ -98,7 +98,7 @@ function check_consistency() {
     check_consistency "$(pem 2)" 6000 0 1 2
 
     # Bring it back.
-    docker start e2e_tendermint-3_1
+    docker start e2e-tendermint-3-1
     sleep 10
     check_consistency "$(pem 1)" 994000 0 1 2 3
     check_consistency "$(pem 2)" 6000 0 1 2 3


### PR DESCRIPTION
- Updated Tendermint to 0.35.4
- Fixed up-down test
- Fixed timers
- Fixed staging file hash
- QoL in Makefile for catch-up test

This part of the project needs love. Developing against it is no fun.

Fixes #177 