### PR TITLE
Rework cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ workflows:
             - CACHE
           matrix:
             parameters:
-              os: [linux2004]
+              os: [linux2204]
           requires:
             - test-v<< matrix.os >>
   release:
@@ -206,7 +206,7 @@ workflows:
           name: create-v<< matrix.os >>
           matrix:
             parameters:
-              os: [linux2004, macos, linux2204]
+              os: [linux2204, macos, linux2204]
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,7 @@ orbs:
   rust: circleci/rust@1.6.0
   detect: circleci/os-detect@0.3.0
 
-rust_cache_path: &rust_cache_path
-  paths:
-    - ~/.cargo
-    - target/
-
 executors:
-  linux2004:
-    machine:
-      image: ubuntu-2004:current
   linux2204:
     machine:
       image: ubuntu-2204:current
@@ -22,88 +14,58 @@ executors:
       xcode: 13.4.1
 
 jobs:
-  lint:
+  lint-test-build:
     parameters:
       os:
-        type: executor
+        type: string
     executor: << parameters.os >>
+    environment:
+      PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so
+      SOFTHSM2_CONF: /tmp/softhsm2.conf
     steps:
       - checkout
       - restore_cache:
           keys:
-            - many-framework-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-framework-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-
+            - cargo-build-{{ .Environment.MANY_FRAMEWORK_CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - rust/format:
-          nightly-toolchain: true
           with_cache: false
       - rust/clippy:
           flags: --all-targets --all-features -- -D clippy::all
           with_cache: false
-
-  build:
-    parameters:
-      os:
-        type: executor
-    executor: << parameters.os >>
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - many-framework-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-framework-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-
-      - rust/install:
-          version: nightly
-      - rust/build:
-          crate: --all-features
-          with_cache: false
-      - save_cache:
-          key: many-framework-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-{{ checksum "Cargo.lock" }}
-          <<: *rust_cache_path
-  test:
-    parameters:
-      os:
-        type: executor
-    executor: << parameters.os >>
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - many-framework-{{ .Environment.CACHE_VERSION }}-test-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-framework-{{ .Environment.CACHE_VERSION }}-test-{{ arch }}-
-            - many-framework-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-framework-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-
-      - rust/install:
-          version: nightly
       - rust/test:
-          package: --lib --all-targets --all-features
+          package: --all-targets --all-features
           with_cache: false
       - rust/test:
           package: --all-features --doc
           with_cache: false
+      - rust/build:
+          crate: --all-features
+          with_cache: false
       - save_cache:
-          key: many-framework-{{ .Environment.CACHE_VERSION }}-test-{{ arch }}-{{ checksum "Cargo.lock" }}
-          <<: *rust_cache_path
+          key: cargo-build-{{ .Environment.MANY_FRAMEWORK_CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+            - target/
   coverage:
     parameters:
       os:
-        type: executor
+        type: string
     executor: << parameters.os >>
     steps:
       - checkout
       - restore_cache:
           keys:
-            - many-framework-{{ .Environment.CACHE_VERSION }}-coverage-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-framework-{{ .Environment.CACHE_VERSION }}-coverage-{{ arch }}-
+            - cargo-coverage-{{ .Environment.MANY_FRAMEWORK_CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - run:
           name: install llvm-tools-preview
           command: rustup component add llvm-tools-preview
-      - run:
-          name: install grcov
-          command: cargo install grcov --root target/
       - run:
           name: generate test coverage
           command: cargo test --all-targets --all-features
@@ -112,16 +74,21 @@ jobs:
             LLVM_PROFILE_FILE: "coverage/lcov-%p-%m.profraw"
       - run:
           name: generate coverage report
-          command: target/bin/grcov src -b target/debug/ -s . --keep-only 'src/**' --prefix-dir $PWD -t lcov --branch --ignore-not-existing -o coverage/report.lcov
+          command: grcov src -b target/debug/ -s . --keep-only 'src/**' --prefix-dir $PWD -t lcov --branch --ignore-not-existing -o coverage/report.lcov
       - codecov/upload:
           file: coverage/report.lcov
       - save_cache:
-          key: many-framework-{{ .Environment.CACHE_VERSION }}-coverage-{{ arch }}-{{ checksum "Cargo.lock" }}
-          <<: *rust_cache_path
+          key: cargo-coverage-{{ .Environment.MANY_FRAMEWORK_CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+            - target/
   create:
     parameters:
       os:
-        type: executor
+        type: string
     executor: << parameters.os >>
     steps:
       - checkout
@@ -171,19 +138,12 @@ jobs:
       - image: rust:latest
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - many-framework-{{ .Environment.CACHE_VERSION }}-audit-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-framework-{{ .Environment.CACHE_VERSION }}-audit-{{ arch }}-
       - run:
           name: install cargo-audit
           command: cargo install cargo-audit
       - run:
           name: cargo audit
           command: cargo audit
-      - save_cache:
-          key: many-framework-{{ .Environment.CACHE_VERSION }}-audit-{{ arch }}-{{ checksum "Cargo.lock" }}
-          <<: *rust_cache_path
 
 # Re-usable commands
 commands:
@@ -202,6 +162,9 @@ commands:
                 command: |
                   sudo DEBIAN_FRONTEND=noninteractive apt -y update
                   sudo DEBIAN_FRONTEND=noninteractive apt -y install build-essential pkg-config clang libssl-dev
+            - run:
+                name: installing grcov
+                command: wget https://github.com/mozilla/grcov/releases/download/v0.8.11/grcov-x86_64-unknown-linux-gnu.tar.bz2 -O - | sudo tar -xj -C /usr/local/bin
 
 workflows:
   ci:
@@ -209,37 +172,23 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - lint:
+      - lint-test-build:
           pre-steps:
             - install-deps:
                 os: << matrix.os >>
-          name: lint-v<< matrix.os >>
+          name: lint-test-build-v<< matrix.os >>
+          context:
+            - CACHE
           matrix:
             parameters:
-              os: [linux2004]
-      - build:
-          pre-steps:
-            - install-deps:
-                os: << matrix.os >>
-          name: build-v<< matrix.os >>
-          matrix:
-            parameters:
-              os: [linux2004, macos]
-      - test:
-          pre-steps:
-            - install-deps:
-                os: << matrix.os >>
-          name: test-v<< matrix.os >>
-          matrix:
-            parameters:
-              os: [linux2004, macos]
-          requires:
-            - build-v<< matrix.os >>
+              os: [linux2204, macos]
       - coverage:
           pre-steps:
             - install-deps:
                 os: << matrix.os >>
           name: coverage-v<< matrix.os >>
+          context:
+            - CACHE
           matrix:
             parameters:
               os: [linux2004]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+# many-rs CI
 version: 2.1
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 # many-framework CI
+# The Lifted Initiative
 version: 2.1
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ workflows:
             parameters:
               os: [linux2204]
           requires:
-            - test-v<< matrix.os >>
+            - lint-test-build-v<< matrix.os >>
   release:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ workflows:
           name: create-v<< matrix.os >>
           matrix:
             parameters:
-              os: [linux2204, macos, linux2204]
+              os: [linux2204]
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# many-rs CI
+# many-framework CI
 version: 2.1
 
 orbs:


### PR DESCRIPTION
macOS cache size: 1.3Gb
Linux build-cache size: 2.7Gb
Linux coverage cache size: 2.5Gb
Total: 6.5Gb

build time from scratch: 33m (16-20mins build, 4.5-6mins cache upload)
build time using the cache: 18m (max 2m cache restore)

Cache depends on the Cargo.lock shasum, i.e., it will be re-created only if the dependencies change.

- Drop Ubuntu 20.04.
- Keep only Ubuntu 22.04 release.
- New CACHE CircleCI context with CACHE version for many-rs and many-framework

Fixes #186 