### PR TITLE
Set CircleCI resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,11 @@ executors:
   linux2204:
     machine:
       image: ubuntu-2204:current
+    resource_class: large
   macos:
     macos:
       xcode: 13.4.1
+    resource_class: medium
 
 jobs:
   lint-test-build:
@@ -146,6 +148,7 @@ jobs:
         default: false
     docker:
       - image: cibuilds/github:0.10
+    resource_class: large
     steps:
       - attach_workspace:
           at: ~/project/artifacts
@@ -165,6 +168,7 @@ jobs:
   audit:
     docker:
       - image: rust:latest
+    resource_class: small
     steps:
       - checkout
       - run:


### PR DESCRIPTION
It is recommended to not rely on the default value.

See https://circleci.com/docs/configuration-reference#resourceclass

