### PR TITLE
Cargo.nix should be always regenerated when possible

### DIFF
--- a/docker/e2e/Makefile
+++ b/docker/e2e/Makefile
@@ -20,7 +20,7 @@ clean:
 	cd ../..; cargo fetch
 	touch $@
 
-Cargo.nix: ../../Cargo.lock
+Cargo.nix:
 	docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v nix-store:/nix -v $(VOLUME):/volume -w /volume/many-framework nixpkgs/nix-flakes bash docker/e2e/generate-cargo-nix.sh
 
 genfiles/many-ledger.tar.gz: $(shell find ../../src -type f) Cargo.nix flake.nix flake.lock


### PR DESCRIPTION
## Description

When cloning the repo, Cargo.nix will be newer than Cargo.lock and will not be regenerated when executing make. This fixes that.

## Related Issue

Fixes #221

## Checklist:

- [X] I have read and followed the CONTRIBUTING guidelines for this project.
- [X] I have added or updated tests and they pass.
- [X] I have added or updated documentation and it is accurate.
- [X] I have noted any breaking changes in this module or downstream modules.
