### PR TITLE
Resiliency tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ orbs:
   rust: circleci/rust@1.6.0
   detect: circleci/os-detect@0.3.0
   bats: circleci/bats@1.0.0
+  docker: circleci/docker@2.1.3
 
 executors:
   linux2204:
@@ -177,6 +178,77 @@ jobs:
       - run:
           name: cargo audit
           command: cargo audit
+  publish_nightly_docker:
+    executor: linux2204
+    resource_class: large
+    steps:
+      - docker/check
+      - checkout:
+          path: many-framework
+      - restore_cache:
+          keys:
+            - nightly-docker-{{ .Environment.MANY_FRAMEWORK_CACHE_VERSION }}-{{ arch }}-{{ checksum "many-framework/Cargo.lock" }}
+      - run:
+          name: restoring `nix-store`
+          command: |
+            if [[ -f "backup.tar" ]]; then
+              docker run --rm -v nix-store:/nix -v $(pwd):/backup ubuntu tar xf /backup/backup.tar -C /
+            else
+              echo "nix-store backup unavailable; skipping."
+            fi
+      - rust/install:
+          version: nightly
+      - run:
+          name: build docker images
+          command: |
+            cd many-framework/docker/e2e
+            make many/many-ledger
+            make many/many-abci
+            docker tag lifted/many-ledger:latest lifted/many-ledger:nightly
+            docker tag lifted/many-abci:latest lifted/many-abci:nightly
+            docker tag lifted/many-ledger:latest lifted/many-ledger:$CIRCLE_SHA1
+            docker tag lifted/many-abci:latest lifted/many-abci:$CIRCLE_SHA1
+      - docker/push:
+          image: many-abci
+          registry: lifted
+          tag: "nightly,$CIRCLE_SHA1"
+          step-name: "docker push lifted/many-abci"
+      - docker/push:
+          image: many-ledger
+          registry: lifted
+          tag: "nightly,$CIRCLE_SHA1"
+          step-name: "docker push lifted/many-ledger"
+      - run:
+          name: exporting `nix-store` docker volume
+          command: |
+            docker run --rm -v nix-store:/nix -v $(pwd):/backup ubuntu tar cf /backup/backup.tar /nix
+      - save_cache:
+          key: nightly-docker-{{ .Environment.MANY_FRAMEWORK_CACHE_VERSION }}-{{ arch }}-{{ checksum "many-framework/Cargo.lock" }}
+          paths:
+            - backup.tar
+  resiliency_tests:
+    executor: linux2204
+    resource_class: large
+    steps:
+      - checkout
+      # TODO: Make a release with `many` CLI and install the release instead
+      - rust/install:
+          version: nightly
+      - run:
+          name: install `many` CLI
+          command: cargo install --git https://github.com/liftedinit/many-rs many
+      - run:
+          name: install `ledger` CLI
+          command: cargo install --path src/ledger ledger
+      - bats/install
+      - docker/pull:
+          images: "lifted/many-ledger:nightly,lifted/many-abci:nightly"
+      - run:
+          name: running BATs tests
+          # https://support.circleci.com/hc/en-us/articles/360046544433-Makefile-Command-Inconsistencies
+          shell: /bin/bash
+          command: bats .
+          working_directory: ./tests/resiliency
 
 # Re-usable commands
 commands:
@@ -296,3 +368,28 @@ workflows:
         - equal: [ "Audit", << pipeline.schedule.name >> ]
     jobs:
       - audit
+  nightly_docker_and_resiliency_tests:
+    when:
+#      and:
+#        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+#        - equal: [ "Nightly Docker and Resiliency Tests", << pipeline.schedule.name >> ]
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - publish_nightly_docker:
+          context:
+            - DOCKER_CREDS
+          filters:
+            branches:
+              only:
+                - main
+      - resiliency_tests:
+          pre-steps:
+            - install-deps:
+                os: linux2204
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - publish_nightly_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,11 +373,9 @@ workflows:
       - audit
   nightly_docker_and_resiliency_tests:
     when:
-#      and:
-#        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-#        - equal: [ "Nightly Docker and Resiliency Tests", << pipeline.schedule.name >> ]
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "Nightly Docker and Resiliency Tests", << pipeline.schedule.name >> ]
     jobs:
       - publish_nightly_docker:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,9 @@ jobs:
           name: install `many` CLI
           command: cargo install --force --git https://github.com/liftedinit/many-rs many
       - run:
+          name: install `ledger` CLI
+          command: cargo install --force --path src/ledger ledger
+      - run:
           name: install cbor-diag
           command: cargo install --force cbor-diag-cli
       - bats/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,3 +393,4 @@ workflows:
                 - main
           requires:
             - publish_nightly_docker
+

--- a/docker/e2e/Cargo.nix
+++ b/docker/e2e/Cargo.nix
@@ -129,13 +129,13 @@ in
     ];
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".asn1."0.8.7" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".asn1."0.11.0" = overridableMkRustCrate (profileName: rec {
     name = "asn1";
-    version = "0.8.7";
+    version = "0.11.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "cfffb35195feaeffb071af0f7a643405667813dd8629c27cb0c310fb76654ab1"; };
+    src = fetchCratesIo { inherit name version; sha256 = "4a0959d3f3489cab2f24b15d637451fe3e8a6b3bfe6bd5ebbc8080fa931a77d3"; };
     dependencies = {
-      chrono = rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.19" { inherit profileName; };
+      chrono = rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.22" { inherit profileName; };
     };
   });
   
@@ -364,6 +364,29 @@ in
       rustc_hash = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc-hash."1.1.0" { inherit profileName; };
       shlex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".shlex."1.1.0" { inherit profileName; };
       which = rustPackages."registry+https://github.com/rust-lang/crates.io-index".which."4.2.5" { inherit profileName; };
+    };
+  });
+  
+  "registry+https://github.com/rust-lang/crates.io-index".bindgen."0.60.1" = overridableMkRustCrate (profileName: rec {
+    name = "bindgen";
+    version = "0.60.1";
+    registry = "registry+https://github.com/rust-lang/crates.io-index";
+    src = fetchCratesIo { inherit name version; sha256 = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"; };
+    features = builtins.concatLists [
+      [ "runtime" ]
+    ];
+    dependencies = {
+      bitflags = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bitflags."1.3.2" { inherit profileName; };
+      cexpr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cexpr."0.6.0" { inherit profileName; };
+      clang_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".clang-sys."1.3.3" { inherit profileName; };
+      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
+      lazycell = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazycell."1.3.0" { inherit profileName; };
+      peeking_take_while = rustPackages."registry+https://github.com/rust-lang/crates.io-index".peeking_take_while."0.1.2" { inherit profileName; };
+      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.42" { inherit profileName; };
+      quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.20" { inherit profileName; };
+      regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.6.0" { inherit profileName; };
+      rustc_hash = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc-hash."1.1.0" { inherit profileName; };
+      shlex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".shlex."1.1.0" { inherit profileName; };
     };
   });
   
@@ -630,27 +653,17 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"; };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.19" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.22" = overridableMkRustCrate (profileName: rec {
     name = "chrono";
-    version = "0.4.19";
+    version = "0.4.22";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"; };
+    src = fetchCratesIo { inherit name version; sha256 = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"; };
     features = builtins.concatLists [
       [ "alloc" ]
-      [ "clock" ]
-      [ "default" ]
-      [ "libc" ]
-      [ "oldtime" ]
-      [ "std" ]
-      [ "time" ]
-      [ "winapi" ]
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.126" { inherit profileName; };
       num_integer = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-integer."0.1.45" { inherit profileName; };
       num_traits = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-traits."0.2.15" { inherit profileName; };
-      time = rustPackages."registry+https://github.com/rust-lang/crates.io-index".time."0.1.44" { inherit profileName; };
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.9" { inherit profileName; };
     };
   });
   
@@ -1538,21 +1551,21 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".enum-iterator."0.8.1" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".enum-iterator."1.2.0" = overridableMkRustCrate (profileName: rec {
     name = "enum-iterator";
-    version = "0.8.1";
+    version = "1.2.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "2953d1df47ac0eb70086ccabf0275aa8da8591a28bd358ee2b52bd9f9e3ff9e9"; };
+    src = fetchCratesIo { inherit name version; sha256 = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"; };
     dependencies = {
-      enum_iterator_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".enum-iterator-derive."0.8.1" { profileName = "__noProfile"; };
+      enum_iterator_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".enum-iterator-derive."1.1.0" { profileName = "__noProfile"; };
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".enum-iterator-derive."0.8.1" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".enum-iterator-derive."1.1.0" = overridableMkRustCrate (profileName: rec {
     name = "enum-iterator-derive";
-    version = "0.8.1";
+    version = "1.1.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"; };
+    src = fetchCratesIo { inherit name version; sha256 = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"; };
     dependencies = {
       proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.42" { inherit profileName; };
       quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.20" { inherit profileName; };
@@ -1698,13 +1711,6 @@ in
       matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.9" { inherit profileName; };
       percent_encoding = rustPackages."registry+https://github.com/rust-lang/crates.io-index".percent-encoding."2.1.0" { inherit profileName; };
     };
-  });
-  
-  "registry+https://github.com/rust-lang/crates.io-index".fs_extra."1.2.0" = overridableMkRustCrate (profileName: rec {
-    name = "fs_extra";
-    version = "1.2.0";
-    registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"; };
   });
   
   "registry+https://github.com/rust-lang/crates.io-index".futures."0.3.21" = overridableMkRustCrate (profileName: rec {
@@ -2148,7 +2154,7 @@ in
       many_modules = rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; };
       minicbor = rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; };
       new_mime_guess = rustPackages."registry+https://github.com/rust-lang/crates.io-index".new_mime_guess."4.0.1" { inherit profileName; };
-      tiny_http = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.9.0" { inherit profileName; };
+      tiny_http = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.11.0" { inherit profileName; };
       tokio = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.20.1" { inherit profileName; };
       tracing = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.35" { inherit profileName; };
       tracing_subscriber = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.15" { inherit profileName; };
@@ -2410,40 +2416,6 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"; };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".jemalloc-sys."0.3.2" = overridableMkRustCrate (profileName: rec {
-    name = "jemalloc-sys";
-    version = "0.3.2";
-    registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"; };
-    features = builtins.concatLists [
-      [ "background_threads_runtime_support" ]
-      [ "disable_initial_exec_tls" ]
-    ];
-    dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.126" { inherit profileName; };
-    };
-    buildDependencies = {
-      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.73" { profileName = "__noProfile"; };
-      fs_extra = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".fs_extra."1.2.0" { profileName = "__noProfile"; };
-    };
-  });
-  
-  "registry+https://github.com/rust-lang/crates.io-index".jemallocator."0.3.2" = overridableMkRustCrate (profileName: rec {
-    name = "jemallocator";
-    version = "0.3.2";
-    registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"; };
-    features = builtins.concatLists [
-      [ "background_threads_runtime_support" ]
-      [ "default" ]
-      [ "disable_initial_exec_tls" ]
-    ];
-    dependencies = {
-      jemalloc_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".jemalloc-sys."0.3.2" { inherit profileName; };
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.126" { inherit profileName; };
-    };
-  });
-  
   "registry+https://github.com/rust-lang/crates.io-index".jobserver."0.1.24" = overridableMkRustCrate (profileName: rec {
     name = "jobserver";
     version = "0.1.24";
@@ -2585,15 +2557,13 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".librocksdb-sys."0.6.1+6.28.2" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".librocksdb-sys."0.8.0+7.4.4" = overridableMkRustCrate (profileName: rec {
     name = "librocksdb-sys";
-    version = "0.6.1+6.28.2";
+    version = "0.8.0+7.4.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"; };
+    src = fetchCratesIo { inherit name version; sha256 = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"; };
     features = builtins.concatLists [
-      [ "bzip2-sys" ]
       [ "default" ]
-      [ "libz-sys" ]
       [ "static" ]
     ];
     dependencies = {
@@ -2602,7 +2572,7 @@ in
       libz_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.1.8" { inherit profileName; };
     };
     buildDependencies = {
-      bindgen = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".bindgen."0.59.2" { profileName = "__noProfile"; };
+      bindgen = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".bindgen."0.60.1" { profileName = "__noProfile"; };
       cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.73" { profileName = "__noProfile"; };
       glob = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".glob."0.3.0" { profileName = "__noProfile"; };
     };
@@ -2696,7 +2666,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-client";
       version = "0.1.0";
-      rev = "20541988a8722a9bd10e2bcf3cb84dc17e1775e4";};
+      rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1";};
     features = builtins.concatLists [
       [ "default" ]
     ];
@@ -2731,7 +2701,7 @@ in
       sha3 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha3."0.9.1" { inherit profileName; };
       signature = rustPackages."registry+https://github.com/rust-lang/crates.io-index".signature."1.3.2" { inherit profileName; };
       static_assertions = rustPackages."registry+https://github.com/rust-lang/crates.io-index".static_assertions."1.1.0" { inherit profileName; };
-      tiny_http = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.9.0" { inherit profileName; };
+      tiny_http = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.11.0" { inherit profileName; };
       tokio = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.20.1" { inherit profileName; };
       tracing = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.35" { inherit profileName; };
     };
@@ -2745,7 +2715,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-error";
       version = "0.1.0";
-      rev = "20541988a8722a9bd10e2bcf3cb84dc17e1775e4";};
+      rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1";};
     features = builtins.concatLists [
       [ "default" ]
       [ "minicbor" ]
@@ -2766,7 +2736,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-identity";
       version = "0.1.0";
-      rev = "20541988a8722a9bd10e2bcf3cb84dc17e1775e4";};
+      rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1";};
     features = builtins.concatLists [
       [ "coset" ]
       [ "default" ]
@@ -2776,7 +2746,7 @@ in
       [ "testing" ]
     ];
     dependencies = {
-      asn1 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".asn1."0.8.7" { inherit profileName; };
+      asn1 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".asn1."0.11.0" { inherit profileName; };
       base32 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".base32."0.4.0" { inherit profileName; };
       coset = rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.2" { inherit profileName; };
       crc_any = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crc-any."2.4.3" { inherit profileName; };
@@ -2822,7 +2792,7 @@ in
       serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.140" { inherit profileName; };
       serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.82" { inherit profileName; };
       sha3 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha3."0.9.1" { inherit profileName; };
-      simple_asn1 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".simple_asn1."0.5.4" { inherit profileName; };
+      simple_asn1 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".simple_asn1."0.6.2" { inherit profileName; };
       tracing = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.35" { inherit profileName; };
       tracing_subscriber = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.15" { inherit profileName; };
       tracing_syslog = rustPackages."git+https://github.com/max-heller/tracing-syslog.git".tracing-syslog."0.1.0" { inherit profileName; };
@@ -2871,7 +2841,7 @@ in
       serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.82" { inherit profileName; };
       sha3 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha3."0.9.1" { inherit profileName; };
       signal_hook = rustPackages."registry+https://github.com/rust-lang/crates.io-index".signal-hook."0.3.14" { inherit profileName; };
-      simple_asn1 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".simple_asn1."0.5.4" { inherit profileName; };
+      simple_asn1 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".simple_asn1."0.6.2" { inherit profileName; };
       strum = rustPackages."registry+https://github.com/rust-lang/crates.io-index".strum."0.24.1" { inherit profileName; };
       tracing = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.35" { inherit profileName; };
       tracing_subscriber = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.15" { inherit profileName; };
@@ -2887,7 +2857,7 @@ in
       tempfile = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tempfile."3.3.0" { inherit profileName; };
     };
     buildDependencies = {
-      vergen = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vergen."6.0.2" { profileName = "__noProfile"; };
+      vergen = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vergen."7.3.2" { profileName = "__noProfile"; };
     };
   });
   
@@ -2899,7 +2869,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-macros";
       version = "0.1.0";
-      rev = "20541988a8722a9bd10e2bcf3cb84dc17e1775e4";};
+      rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1";};
     dependencies = {
       inflections = rustPackages."registry+https://github.com/rust-lang/crates.io-index".inflections."1.1.1" { inherit profileName; };
       proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.42" { inherit profileName; };
@@ -2918,7 +2888,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-modules";
       version = "0.1.0";
-      rev = "20541988a8722a9bd10e2bcf3cb84dc17e1775e4";};
+      rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1";};
     dependencies = {
       async_trait = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".async-trait."0.1.56" { profileName = "__noProfile"; };
       coset = rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.2" { inherit profileName; };
@@ -2944,7 +2914,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-protocol";
       version = "0.1.0";
-      rev = "20541988a8722a9bd10e2bcf3cb84dc17e1775e4";};
+      rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1";};
     dependencies = {
       base64 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.0" { inherit profileName; };
       coset = rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.2" { inherit profileName; };
@@ -2975,13 +2945,13 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-server";
       version = "0.1.0";
-      rev = "20541988a8722a9bd10e2bcf3cb84dc17e1775e4";};
+      rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1";};
     features = builtins.concatLists [
       [ "default" ]
     ];
     dependencies = {
       anyhow = rustPackages."registry+https://github.com/rust-lang/crates.io-index".anyhow."1.0.58" { inherit profileName; };
-      asn1 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".asn1."0.8.7" { inherit profileName; };
+      asn1 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".asn1."0.11.0" { inherit profileName; };
       async_trait = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".async-trait."0.1.56" { profileName = "__noProfile"; };
       base32 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".base32."0.4.0" { inherit profileName; };
       base64 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.0" { inherit profileName; };
@@ -3019,7 +2989,7 @@ in
       static_assertions = rustPackages."registry+https://github.com/rust-lang/crates.io-index".static_assertions."1.1.0" { inherit profileName; };
       strum = rustPackages."registry+https://github.com/rust-lang/crates.io-index".strum."0.24.1" { inherit profileName; };
       strum_macros = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".strum_macros."0.24.2" { profileName = "__noProfile"; };
-      tiny_http = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.9.0" { inherit profileName; };
+      tiny_http = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.11.0" { inherit profileName; };
       tokio = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.20.1" { inherit profileName; };
       tracing = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.35" { inherit profileName; };
     };
@@ -3033,7 +3003,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-types";
       version = "0.1.0";
-      rev = "20541988a8722a9bd10e2bcf3cb84dc17e1775e4";};
+      rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1";};
     dependencies = {
       coset = rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.2" { inherit profileName; };
       fixed = rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.16.1" { inherit profileName; };
@@ -3081,7 +3051,7 @@ in
       url = https://github.com/liftedinit/merk.git;
       name = "merk";
       version = "1.0.0";
-      rev = "f45dde4dd0f5337acb0698da7fbb32d088d0ea9b";};
+      rev = "da0b660abbfd58abd4a942773f205d2c079f3b27";};
     features = builtins.concatLists [
       [ "blake3" ]
       [ "byteorder" ]
@@ -3090,7 +3060,6 @@ in
       [ "ed" ]
       [ "full" ]
       [ "hex" ]
-      [ "jemallocator" ]
       [ "num_cpus" ]
       [ "rand" ]
       [ "rocksdb" ]
@@ -3102,10 +3071,9 @@ in
       colored = rustPackages."registry+https://github.com/rust-lang/crates.io-index".colored."1.9.3" { inherit profileName; };
       ed = rustPackages."git+https://github.com/nomic-io/ed".ed."0.2.2-alpha.0" { inherit profileName; };
       hex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; };
-      jemallocator = rustPackages."registry+https://github.com/rust-lang/crates.io-index".jemallocator."0.3.2" { inherit profileName; };
       num_cpus = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num_cpus."1.13.1" { inherit profileName; };
       rand = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand."0.8.5" { inherit profileName; };
-      rocksdb = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rocksdb."0.18.0" { inherit profileName; };
+      rocksdb = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rocksdb."0.19.0" { inherit profileName; };
       thiserror = rustPackages."registry+https://github.com/rust-lang/crates.io-index".thiserror."1.0.31" { inherit profileName; };
     };
   });
@@ -4211,14 +4179,14 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".rocksdb."0.18.0" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".rocksdb."0.19.0" = overridableMkRustCrate (profileName: rec {
     name = "rocksdb";
-    version = "0.18.0";
+    version = "0.19.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"; };
+    src = fetchCratesIo { inherit name version; sha256 = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"; };
     dependencies = {
       libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.126" { inherit profileName; };
-      librocksdb_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".librocksdb-sys."0.6.1+6.28.2" { inherit profileName; };
+      librocksdb_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".librocksdb-sys."0.8.0+7.4.4" { inherit profileName; };
     };
   });
   
@@ -4691,16 +4659,16 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".simple_asn1."0.5.4" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".simple_asn1."0.6.2" = overridableMkRustCrate (profileName: rec {
     name = "simple_asn1";
-    version = "0.5.4";
+    version = "0.6.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"; };
+    src = fetchCratesIo { inherit name version; sha256 = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"; };
     dependencies = {
-      chrono = rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.19" { inherit profileName; };
       num_bigint = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; };
       num_traits = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-traits."0.2.15" { inherit profileName; };
       thiserror = rustPackages."registry+https://github.com/rust-lang/crates.io-index".thiserror."1.0.31" { inherit profileName; };
+      time = rustPackages."registry+https://github.com/rust-lang/crates.io-index".time."0.3.11" { inherit profileName; };
     };
   });
   
@@ -4915,17 +4883,17 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".sysinfo."0.23.13" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".sysinfo."0.24.7" = overridableMkRustCrate (profileName: rec {
     name = "sysinfo";
-    version = "0.23.13";
+    version = "0.24.7";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "3977ec2e0520829be45c8a2df70db2bf364714d8a748316a10c3c35d4d2b01c9"; };
+    src = fetchCratesIo { inherit name version; sha256 = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"; };
     dependencies = {
       cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."1.0.0" { inherit profileName; };
       ${ if hostPlatform.parsed.kernel.name == "darwin" || hostPlatform.parsed.kernel.name == "ios" then "core_foundation_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".core-foundation-sys."0.8.3" { inherit profileName; };
       ${ if !(hostPlatform.parsed.kernel.name == "unknown" || hostPlatform.parsed.cpu.name == "wasm32") then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.126" { inherit profileName; };
       ${ if hostPlatform.isWindows then "ntapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ntapi."0.3.7" { inherit profileName; };
-      once_cell = rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.13.0" { inherit profileName; };
+      ${ if hostPlatform.isWindows || hostPlatform.parsed.kernel.name == "linux" || hostPlatform.parsed.kernel.name == "android" then "once_cell" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.13.0" { inherit profileName; };
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.9" { inherit profileName; };
     };
   });
@@ -5158,18 +5126,6 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".time."0.1.44" = overridableMkRustCrate (profileName: rec {
-    name = "time";
-    version = "0.1.44";
-    registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"; };
-    dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.126" { inherit profileName; };
-      ${ if hostPlatform.parsed.kernel.name == "wasi" then "wasi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".wasi."0.10.0+wasi-snapshot-preview1" { inherit profileName; };
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.9" { inherit profileName; };
-    };
-  });
-  
   "registry+https://github.com/rust-lang/crates.io-index".time."0.3.11" = overridableMkRustCrate (profileName: rec {
     name = "time";
     version = "0.3.11";
@@ -5177,12 +5133,16 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"; };
     features = builtins.concatLists [
       [ "alloc" ]
+      [ "default" ]
+      [ "formatting" ]
+      [ "itoa" ]
       [ "macros" ]
       [ "parsing" ]
       [ "std" ]
       [ "time-macros" ]
     ];
     dependencies = {
+      itoa = rustPackages."registry+https://github.com/rust-lang/crates.io-index".itoa."1.0.2" { inherit profileName; };
       ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.126" { inherit profileName; };
       ${ if hostPlatform.isUnix then "num_threads" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num_threads."0.1.6" { inherit profileName; };
       time_macros = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".time-macros."0.2.4" { profileName = "__noProfile"; };
@@ -5196,19 +5156,19 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"; };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.9.0" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.11.0" = overridableMkRustCrate (profileName: rec {
     name = "tiny_http";
-    version = "0.9.0";
+    version = "0.11.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "96155b5f7149ba7a99ea5d516c538250b26eab60b4485c0f5344432573e7a450"; };
+    src = fetchCratesIo { inherit name version; sha256 = "e0d6ef4e10d23c1efb862eecad25c5054429a71958b4eeef85eb5e7170b477ca"; };
     features = builtins.concatLists [
       [ "default" ]
     ];
     dependencies = {
       ascii = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ascii."1.0.0" { inherit profileName; };
-      chrono = rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.19" { inherit profileName; };
       chunked_transfer = rustPackages."registry+https://github.com/rust-lang/crates.io-index".chunked_transfer."1.4.0" { inherit profileName; };
       log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.17" { inherit profileName; };
+      time = rustPackages."registry+https://github.com/rust-lang/crates.io-index".time."0.3.11" { inherit profileName; };
       url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.2.2" { inherit profileName; };
     };
   });
@@ -5608,15 +5568,14 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"; };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".vergen."6.0.2" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".vergen."7.3.2" = overridableMkRustCrate (profileName: rec {
     name = "vergen";
-    version = "6.0.2";
+    version = "7.3.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "3893329bee75c101278e0234b646fa72221547d63f97fb66ac112a0569acd110"; };
+    src = fetchCratesIo { inherit name version; sha256 = "3bbc4fafd30514504c7593cfa52eaf4d6c4ef660386e2ec54edc17f14aa08e8d"; };
     features = builtins.concatLists [
       [ "build" ]
       [ "cargo" ]
-      [ "chrono" ]
       [ "default" ]
       [ "git" ]
       [ "git2" ]
@@ -5624,21 +5583,23 @@ in
       [ "rustc_version" ]
       [ "si" ]
       [ "sysinfo" ]
+      [ "time" ]
     ];
     dependencies = {
       anyhow = rustPackages."registry+https://github.com/rust-lang/crates.io-index".anyhow."1.0.58" { inherit profileName; };
       cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."1.0.0" { inherit profileName; };
-      chrono = rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.19" { inherit profileName; };
-      enum_iterator = rustPackages."registry+https://github.com/rust-lang/crates.io-index".enum-iterator."0.8.1" { inherit profileName; };
+      enum_iterator = rustPackages."registry+https://github.com/rust-lang/crates.io-index".enum-iterator."1.2.0" { inherit profileName; };
       getset = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".getset."0.1.2" { profileName = "__noProfile"; };
       git2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".git2."0.14.4" { inherit profileName; };
       rustc_version = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc_version."0.4.0" { inherit profileName; };
-      sysinfo = rustPackages."registry+https://github.com/rust-lang/crates.io-index".sysinfo."0.23.13" { inherit profileName; };
+      sysinfo = rustPackages."registry+https://github.com/rust-lang/crates.io-index".sysinfo."0.24.7" { inherit profileName; };
       thiserror = rustPackages."registry+https://github.com/rust-lang/crates.io-index".thiserror."1.0.31" { inherit profileName; };
+      time = rustPackages."registry+https://github.com/rust-lang/crates.io-index".time."0.3.11" { inherit profileName; };
     };
     buildDependencies = {
-      chrono = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.19" { profileName = "__noProfile"; };
+      anyhow = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".anyhow."1.0.58" { profileName = "__noProfile"; };
       rustversion = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".rustversion."1.0.8" { profileName = "__noProfile"; };
+      time = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".time."0.3.11" { profileName = "__noProfile"; };
     };
   });
   
@@ -5694,17 +5655,6 @@ in
     version = "0.9.0+wasi-snapshot-preview1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"; };
-    features = builtins.concatLists [
-      [ "default" ]
-      [ "std" ]
-    ];
-  });
-  
-  "registry+https://github.com/rust-lang/crates.io-index".wasi."0.10.0+wasi-snapshot-preview1" = overridableMkRustCrate (profileName: rec {
-    name = "wasi";
-    version = "0.10.0+wasi-snapshot-preview1";
-    registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"; };
     features = builtins.concatLists [
       [ "default" ]
       [ "std" ]
@@ -5903,6 +5853,7 @@ in
       [ "evntrace" ]
       [ "fileapi" ]
       [ "handleapi" ]
+      [ "heapapi" ]
       [ "ifdef" ]
       [ "impl-debug" ]
       [ "impl-default" ]
@@ -5918,7 +5869,7 @@ in
       [ "minwindef" ]
       [ "namedpipeapi" ]
       [ "netioapi" ]
-      [ "ntdef" ]
+      [ "ntlsa" ]
       [ "ntsecapi" ]
       [ "objidl" ]
       [ "oleauto" ]
@@ -5926,9 +5877,9 @@ in
       [ "powerbase" ]
       [ "processenv" ]
       [ "processthreadsapi" ]
-      [ "profileapi" ]
       [ "psapi" ]
       [ "rpcdce" ]
+      [ "securitybaseapi" ]
       [ "shellapi" ]
       [ "std" ]
       [ "synchapi" ]

--- a/docker/e2e/Makefile
+++ b/docker/e2e/Makefile
@@ -3,11 +3,14 @@ NB_NODES ?= 4
 ID_WITH_BALANCES ?=
 CPUCORES ?= $$(nproc)
 TENDERMINT_VERSION ?= 0.35.4
+ABCI_TAG ?= "latest"
+LEDGER_TAG ?= "latest"
 
 # Constants
 VOLUME = $(abspath $(dir $(abspath $(dir $(abspath $(dir $(abspath $(dir $$PWD))))))))
 UINFO = $$(id -u):$$(id -g)
 BUILDER_COMMAND = docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v $(VOLUME):/volume -v nix-store:/nix -w /volume/many-framework/docker/e2e/ nixpkgs/nix-flakes bash build-image.sh $@
+SHELL = bash
 
 .PHONY: clean
 clean:
@@ -20,7 +23,7 @@ clean:
 	cd ../..; cargo fetch
 	touch $@
 
-Cargo.nix:
+Cargo.nix: ../../Cargo.lock
 	docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v nix-store:/nix -v $(VOLUME):/volume -w /volume/many-framework nixpkgs/nix-flakes bash docker/e2e/generate-cargo-nix.sh
 
 genfiles/many-ledger.tar.gz: $(shell find ../../src -type f) Cargo.nix flake.nix flake.lock
@@ -60,6 +63,8 @@ genfiles/docker-compose.json: genfiles/jsonnet-docker docker-compose.jsonnet
 		--tla-code nb_nodes=$(NB_NODES) \
 		--tla-code user=$$(id -u) \
 		--tla-code id_with_balances=\"$(ID_WITH_BALANCES)\" \
+		--tla-code abci_tag=\"$(ABCI_TAG)\" \
+		--tla-code ledger_tag=\"$(LEDGER_TAG)\" \
 		--tla-code tendermint_tag=\"$(TENDERMINT_VERSION)\" \
 		-o /$@
 
@@ -77,22 +82,22 @@ genfiles/generate-tendermint-e2e-config:
 		make genfiles/node$$I; \
 		(( I = I + 1 )); \
 	done
-	sh update_config.sh -c "genfiles/node%/tendermint/config" -i tendermint-% $(NB_NODES)
+	bash update_config.sh -c "genfiles/node%/tendermint/config" -i tendermint-% $(NB_NODES)
 	mkdir -p $(dir $@) && touch $@
 
 .PHONY: start-nodes
 start-nodes: many/many-ledger many/many-abci genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e up
 
-.PHONE: start-abci-%
+.PHONY: start-abci-%
 start-abci-%: genfiles/docker-compose.json many/many-abci
 	docker-compose -f genfiles/docker-compose.json -p e2e up abci-$*
 
-.PHONE: start-ledger-%
+.PHONY: start-ledger-%
 start-ledger-%: genfiles/docker-compose.json many/many-ledger genfiles/generate-tendermint-e2e-config
 	docker-compose -f genfiles/docker-compose.json -p e2e up ledger-$*
 
-.PHONE: start-tendermint-%
+.PHONY: start-tendermint-%
 start-tendermint-%: genfiles/docker-compose.json genfiles/generate-tendermint-e2e-config
 	docker-compose -f genfiles/docker-compose.json -p e2e up tendermint-$*
 
@@ -100,34 +105,56 @@ start-tendermint-%: genfiles/docker-compose.json genfiles/generate-tendermint-e2
 down-nodes: genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e down
 
-.PHONE: down-abci-%
+.PHONY: down-abci-%
 down-abci-%: genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e down abci-$*
 
-.PHONE: down-ledger-%
+.PHONY: down-ledger-%
 down-ledger-%: genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e down ledger-$*
 
-.PHONE: down-tendermint-%
+.PHONY: down-tendermint-%
 down-tendermint-%: genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e down tendermint-$*
 
-.PHONE: stop-nodes
+.PHONY: stop-nodes
 stop-nodes: genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e stop
 
-.PHONE: stop-abci-%
+.PHONY: stop-single-node-%
+stop-single-node-%: genfiles/docker-compose.json
+	docker-compose -f genfiles/docker-compose.json -p e2e stop abci-$*
+	docker-compose -f genfiles/docker-compose.json -p e2e stop ledger-$*
+	docker-compose -f genfiles/docker-compose.json -p e2e stop tendermint-$*
+
+.PHONY: stop-abci-%
 stop-abci-%: genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e stop abci-$*
 
-.PHONE: stop-ledger-%
+.PHONY: stop-ledger-%
 start-ledger-%: genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e stop ledger-$*
 
-.PHONE: stop-tendermint-%
+.PHONY: stop-tendermint-%
 stop-tendermint-%: genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e stop tendermint-$*
 
 .PHONY: start-nodes-dettached
 start-nodes-dettached: many/many-ledger many/many-abci genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
 	docker-compose -f genfiles/docker-compose.json -p e2e up --detach
+
+.PHONY: start-nodes-dettached-no-img-regen
+start-nodes-dettached-no-img-regen: genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
+	docker-compose -f genfiles/docker-compose.json -p e2e up --detach
+
+.PHONY: start-single-node-dettached-%
+start-single-node-dettached-%: many/many-ledger many/many-abci genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
+	docker-compose -f genfiles/docker-compose.json -p e2e up abci-$* --detach
+	docker-compose -f genfiles/docker-compose.json -p e2e up ledger-$* --detach
+	docker-compose -f genfiles/docker-compose.json -p e2e up tendermint-$* --detach
+
+.PHONY: start-single-node-dettached-no-img-regen-%
+start-single-node-dettached-no-img-regen-%: genfiles/generate-tendermint-e2e-config genfiles/docker-compose.json
+	docker-compose -f genfiles/docker-compose.json -p e2e up abci-$* --detach
+	docker-compose -f genfiles/docker-compose.json -p e2e up ledger-$* --detach
+	docker-compose -f genfiles/docker-compose.json -p e2e up tendermint-$* --detach

--- a/docker/e2e/docker-compose.jsonnet
+++ b/docker/e2e/docker-compose.jsonnet
@@ -14,8 +14,8 @@ local generate_balance_flags(id_with_balances="", token="mqbfbahksdwaqeenayy2gxk
     );
 
 
-local abci(i, user) = {
-    image: "many/many-abci",
+local abci(i, user, abci_tag) = {
+    image: "lifted/many-abci:" + abci_tag,
     ports: [ (8000 + i) + ":8000" ],
     volumes: [ "./node" + i + ":/genfiles:ro" ],
     user: "" + user,
@@ -31,8 +31,8 @@ local abci(i, user) = {
     depends_on: [ "ledger-" + i ],
 };
 
-local ledger(i, user, id_with_balances) = {
-    image: "many/many-ledger",
+local ledger(i, user, id_with_balances, ledger_tag) = {
+    image: "lifted/many-ledger:" + ledger_tag,
     user: "" + user,
     volumes: [
         "./node" + i + "/persistent-ledger:/persistent",
@@ -64,12 +64,12 @@ local tendermint(i, user, tendermint_tag) = {
     ports: [ "" + (26600 + i) + ":26600" ],
 };
 
-function(nb_nodes=4, user=1000, id_with_balances="", tendermint_tag="0.35.4") {
+function(nb_nodes=4, user=1000, id_with_balances="", tendermint_tag="0.35.4", abci_tag="latest", ledger_tag="latest") {
     version: '3',
     services: {
-        ["abci-" + i]: abci(i, user) for i in std.range(0, nb_nodes - 1)
+        ["abci-" + i]: abci(i, user, abci_tag) for i in std.range(0, nb_nodes - 1)
     } + {
-        ["ledger-" + i]: ledger(i, user, id_with_balances) for i in std.range(0, nb_nodes - 1)
+        ["ledger-" + i]: ledger(i, user, id_with_balances, ledger_tag) for i in std.range(0, nb_nodes - 1)
     } + {
         ["tendermint-" + i]: tendermint(i, user, tendermint_tag) for i in std.range(0, nb_nodes - 1)
     },

--- a/docker/e2e/flake.nix
+++ b/docker/e2e/flake.nix
@@ -27,7 +27,7 @@
 
           dockerImageFromPkg = pkg: name: final.dockerTools.buildLayeredImage {
             fromImage = final.baseImage;
-            name = "many/${name}";
+            name = "lifted/${name}";
             tag = "latest";
             contents = [
               (pkg {}).bin

--- a/tests/e2e/ledger.bats
+++ b/tests/e2e/ledger.bats
@@ -33,18 +33,18 @@ function teardown() {
 }
 
 @test "$SUITE: ledger can send tokens on behalf of an account" {
-    account_id=$(account_create "$(pem 1)" '{ 1: { "'"$(identity 2)"'": ["canLedgerTransact"] }, 2: [0] }')
-    call_ledger "$(pem 1)" 0 send "$account_id" 1000000 MFX
-    check_consistency "$(pem 1)" 1000000 "$account_id" 0
+    account_id=$(account_create --pem=1 '{ 1: { "'"$(identity 2)"'": ["canLedgerTransact"] }, 2: [0] }')
+    call_ledger --pem=1 --port=8000 send "$account_id" 1000000 MFX
+    check_consistency --pem=1 --balance=1000000 --id="$account_id" 8000
 
-    call_ledger "$(pem 1)" 0 send --account="$account_id" "$(identity 4)" 2000 MFX
-    check_consistency "$(pem 4)" 2000 "$(pem 4)" 0
-    check_consistency "$(pem 1)" 998000 "$account_id" 0
+    call_ledger --pem=1 --port=8000 send --account="$account_id" "$(identity 4)" 2000 MFX
+    check_consistency --pem=4 --balance=2000 --id="$(identity 4)" 8000
+    check_consistency --pem=1 --balance=998000 --id="$account_id" 8000
 
-    call_ledger "$(pem 2)" 0 send --account="$account_id" "$(identity 4)" 2000 MFX
-    check_consistency "$(pem 4)" 4000 "$(pem 4)" 0
-    check_consistency "$(pem 1)" 996000 "$account_id" 0
+    call_ledger --pem=2 --port=8000 send --account="$account_id" "$(identity 4)" 2000 MFX
+    check_consistency --pem=4 --balance=4000 --id="$(identity 4)" 8000
+    check_consistency --pem=1 --balance=996000 --id="$account_id" 8000
 
-    call_ledger "$(pem 4)" 0 send --account="$account_id" "$(identity 4)" 2000 MFX
+    call_ledger --pem=4 --port=8000 send --account="$account_id" "$(identity 4)" 2000 MFX
     assert_output --partial "Sender needs role 'canLedgerTransact' to perform this operation."
 }

--- a/tests/e2e/ledger.bats
+++ b/tests/e2e/ledger.bats
@@ -32,18 +32,19 @@ function teardown() {
     stop_background_run
 }
 
-@test "$SUITE: Ledger can send tokens on behalf of an account" {
-    account_id=$(account_create --id=1 '{ 1: { "'"$(identity 2)"'": ["canLedgerTransact"] }, 2: [0] }')
-    ledger --id=1 send "$account_id" 1000000 MFX
-    ledger --balance=1000000 --id=1 balance "$account_id"
+@test "$SUITE: ledger can send tokens on behalf of an account" {
+    account_id=$(account_create "$(pem 1)" '{ 1: { "'"$(identity 2)"'": ["canLedgerTransact"] }, 2: [0] }')
+    call_ledger "$(pem 1)" 0 send "$account_id" 1000000 MFX
+    check_consistency "$(pem 1)" 1000000 "$account_id" 0
 
-    ledger --id=1 send --account="$account_id" "$(identity 4)" 2000 MFX
-    ledger --id=4 --balance=2000 balance
-    ledger --id=1 --balance=998000 balance "$account_id"
+    call_ledger "$(pem 1)" 0 send --account="$account_id" "$(identity 4)" 2000 MFX
+    check_consistency "$(pem 4)" 2000 "$(pem 4)" 0
+    check_consistency "$(pem 1)" 998000 "$account_id" 0
 
-    ledger --id=2 send --account="$account_id" "$(identity 4)" 2000 MFX
-    ledger --id=4 --balance=4000 balance
-    ledger --id=1 --balance=996000 balance "$account_id"
+    call_ledger "$(pem 2)" 0 send --account="$account_id" "$(identity 4)" 2000 MFX
+    check_consistency "$(pem 4)" 4000 "$(pem 4)" 0
+    check_consistency "$(pem 1)" 996000 "$account_id" 0
 
-    ledger --error --id=4 send --account="$account_id" "$(identity 4)" 2000 MFX
+    call_ledger "$(pem 4)" 0 send --account="$account_id" "$(identity 4)" 2000 MFX
+    assert_output --partial "Sender needs role 'canLedgerTransact' to perform this operation."
 }

--- a/tests/e2e/multisig.bats
+++ b/tests/e2e/multisig.bats
@@ -33,81 +33,69 @@ function teardown() {
 }
 
 @test "$SUITE: Ledger shows a balance and can send tokens" {
-    ledger --id=1 balance
-    assert_output --partial "$START_BALANCE MFX"
+    check_consistency "$(pem 1)" $START_BALANCE "$(pem 1)" 0
 
-    ledger --id=1 send "$(identity 3)" 1000 MFX
+    call_ledger "$(pem 1)" 0 send "$(identity 3)" 1000 MFX
+    check_consistency "$(pem 3)" 1000 "$(pem 3)" 0
+    check_consistency "$(pem 1)" $((START_BALANCE - 1000)) "$(pem 1)" 0
 
-    ledger --id=3 balance
-    assert_output --partial "1000 MFX"
-
-    ledger --id=1 balance
-    assert_output --partial "$((START_BALANCE - 1000)) MFX"
-
-    ledger --id=2 balance
-    assert_output --partial "$START_BALANCE MFX"
+    check_consistency "$(pem 2)" $START_BALANCE "$(pem 2)" 0
 }
 
 @test "$SUITE: Ledger can do account creation and multisig transactions" {
     local account_id
     local tx_id
 
-    ledger --id=1 balance
-    assert_output --partial "$START_BALANCE MFX"
+    check_consistency "$(pem 1)" $START_BALANCE "$(pem 1)" 0
+    account_id=$(account_create "$(pem 1)" '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')
 
-    account_id=$(account_create --id=1 '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')
+    call_ledger "$(pem 1)" 0 send "$account_id" 1000000 MFX
+    check_consistency "$(pem 1)" 1000000 "$account_id" 0
 
-    ledger --id=1 send "$account_id" 1000000 MFX
-    ledger --id=1 balance "$account_id"
-    assert_output --partial "1000000 MFX"
-
-    ledger --id=1 multisig submit "$account_id" send "$(identity 3)" 100 MFX
+    call_ledger "$(pem 1)" 0 multisig submit "$account_id" send "$(identity 3)" 100 MFX
     tx_id=$(echo "$output" | grep -oE "[0-9a-f]+$")
     # Cannot execute if not approved.
-    ledger --error --id=1 multisig execute "$tx_id"
+    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
+    assert_output --partial "This transaction cannot be executed yet."
 
-    ledger --id=2 multisig approve "$tx_id"
+    call_ledger "$(pem 2)" 0 multisig approve "$tx_id"
 
     # Cannot execute if not submitted.
-    ledger --error --id=2 multisig execute "$tx_id"
+    call_ledger "$(pem 2)" 0 multisig execute "$tx_id"
+    assert_output --partial "This transaction cannot be executed yet."
 
-    ledger --id=1 multisig execute "$tx_id"
+    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
 
-    ledger --id=1 balance "$account_id"
-    assert_output --partial "999900 MFX"
-
-    ledger --id=3 balance
-    assert_output --partial "100 MFX"
+    check_consistency "$(pem 1)" 999900 "$account_id" 0
+    check_consistency "$(pem 3)" 100 "$(pem 3)" 0
 }
 
 @test "$SUITE: can revoke" {
     local account_id
     local tx_id
 
-    ledger --id=1 balance
-    assert_output --partial "$START_BALANCE MFX"
+    check_consistency "$(pem 1)" $START_BALANCE "$(pem 1)" 0
+    account_id=$(account_create "$(pem 1)" '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')
 
-    account_id=$(account_create --id=1 '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')
+    call_ledger "$(pem 1)" 0 send "$account_id" 1000000 MFX
+    check_consistency "$(pem 1)" 1000000 "$account_id" 0
 
-    ledger --id=1 send "$account_id" 1000000 MFX
-    ledger --id=1 balance "$account_id"
-    assert_output --partial "1000000 MFX"
-
-    ledger --id=1 multisig submit "$account_id" send "$(identity 3)" 100 MFX
+    call_ledger "$(pem 1)" 0 multisig submit "$account_id" send "$(identity 3)" 100 MFX
     tx_id=$(echo "$output" | grep -oE "[0-9a-f]+$")
 
-    ledger --id=2 multisig approve "$tx_id"
-    ledger --id=1 multisig revoke "$tx_id"
+    call_ledger "$(pem 2)" 0 multisig approve "$tx_id"
+    call_ledger "$(pem 1)" 0 multisig revoke "$tx_id"
 
-    ledger --error --id=1 multisig execute "$tx_id"
+    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
+    assert_output --partial "This transaction cannot be executed yet."
 
-    ledger --id=1 multisig approve "$tx_id"
-    ledger --id=2 multisig revoke "$tx_id"
-    ledger --error --id=1 multisig execute "$tx_id"
+    call_ledger "$(pem 1)" 0 multisig approve "$tx_id"
+    call_ledger "$(pem 2)" 0 multisig revoke "$tx_id"
+    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
+    assert_output --partial "This transaction cannot be executed yet."
 
-    ledger --id=2 multisig approve "$tx_id"
-    ledger --id=1 multisig execute "$tx_id"
+    call_ledger "$(pem 2)" 0 multisig approve "$tx_id"
+    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
 
-    ledger --id=3 balance
-    assert_output --partial "100 MFX"
+    check_consistency "$(pem 3)" 100 "$(pem 3)" 0
 }

--- a/tests/e2e/multisig.bats
+++ b/tests/e2e/multisig.bats
@@ -33,69 +33,69 @@ function teardown() {
 }
 
 @test "$SUITE: Ledger shows a balance and can send tokens" {
-    check_consistency "$(pem 1)" $START_BALANCE "$(pem 1)" 0
+    check_consistency --pem=1 --balance=$START_BALANCE --id="$(identity 1)" 8000
 
-    call_ledger "$(pem 1)" 0 send "$(identity 3)" 1000 MFX
-    check_consistency "$(pem 3)" 1000 "$(pem 3)" 0
-    check_consistency "$(pem 1)" $((START_BALANCE - 1000)) "$(pem 1)" 0
+    call_ledger --pem=1 --port=8000 send "$(identity 3)" 1000 MFX
+    check_consistency --pem=3 --balance=1000 --id="$(identity 3)" 8000
+    check_consistency --pem=1 --balance=$((START_BALANCE - 1000)) --id="$(identity 1)" 8000
 
-    check_consistency "$(pem 2)" $START_BALANCE "$(pem 2)" 0
+    check_consistency --pem=2 --balance=$START_BALANCE --id="$(identity 2)" 8000
 }
 
 @test "$SUITE: Ledger can do account creation and multisig transactions" {
     local account_id
     local tx_id
 
-    check_consistency "$(pem 1)" $START_BALANCE "$(pem 1)" 0
-    account_id=$(account_create "$(pem 1)" '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')
+    check_consistency --pem=1 --balance=$START_BALANCE --id="$(identity 1)" 8000
+    account_id=$(account_create --pem=1 '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')
 
-    call_ledger "$(pem 1)" 0 send "$account_id" 1000000 MFX
-    check_consistency "$(pem 1)" 1000000 "$account_id" 0
+    call_ledger --pem=1 --port=8000 send "$account_id" 1000000 MFX
+    check_consistency --pem=1 --balance=1000000 --id="$account_id" 8000
 
-    call_ledger "$(pem 1)" 0 multisig submit "$account_id" send "$(identity 3)" 100 MFX
+    call_ledger --pem=1 --port=8000 multisig submit "$account_id" send "$(identity 3)" 100 MFX
     tx_id=$(echo "$output" | grep -oE "[0-9a-f]+$")
     # Cannot execute if not approved.
-    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
+    call_ledger --pem=1 --port=8000 multisig execute "$tx_id"
     assert_output --partial "This transaction cannot be executed yet."
 
-    call_ledger "$(pem 2)" 0 multisig approve "$tx_id"
+    call_ledger --pem=2 --port=8000 multisig approve "$tx_id"
 
     # Cannot execute if not submitted.
-    call_ledger "$(pem 2)" 0 multisig execute "$tx_id"
+    call_ledger --pem=2 --port=8000 multisig execute "$tx_id"
     assert_output --partial "This transaction cannot be executed yet."
 
-    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
+    call_ledger --pem=1 --port=8000 multisig execute "$tx_id"
 
-    check_consistency "$(pem 1)" 999900 "$account_id" 0
-    check_consistency "$(pem 3)" 100 "$(pem 3)" 0
+    check_consistency --pem=1 --balance=999900 --id="$account_id" 8000
+    check_consistency --pem=3 --balance=100 --id="$(identity 3)" 8000
 }
 
 @test "$SUITE: can revoke" {
     local account_id
     local tx_id
 
-    check_consistency "$(pem 1)" $START_BALANCE "$(pem 1)" 0
-    account_id=$(account_create "$(pem 1)" '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')
+    check_consistency --pem=1 --balance=$START_BALANCE --id="$(identity 1)" 8000
+    account_id=$(account_create --pem=1 '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')
 
-    call_ledger "$(pem 1)" 0 send "$account_id" 1000000 MFX
-    check_consistency "$(pem 1)" 1000000 "$account_id" 0
+    call_ledger --pem=1 --port=8000 send "$account_id" 1000000 MFX
+    check_consistency --pem=1 --balance=1000000 --id="$account_id" 8000
 
-    call_ledger "$(pem 1)" 0 multisig submit "$account_id" send "$(identity 3)" 100 MFX
+    call_ledger --pem=1 --port=8000 multisig submit "$account_id" send "$(identity 3)" 100 MFX
     tx_id=$(echo "$output" | grep -oE "[0-9a-f]+$")
 
-    call_ledger "$(pem 2)" 0 multisig approve "$tx_id"
-    call_ledger "$(pem 1)" 0 multisig revoke "$tx_id"
+    call_ledger --pem=2 --port=8000 multisig approve "$tx_id"
+    call_ledger --pem=1 --port=8000 multisig revoke "$tx_id"
 
-    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
+    call_ledger --pem=1 --port=8000 multisig execute "$tx_id"
     assert_output --partial "This transaction cannot be executed yet."
 
-    call_ledger "$(pem 1)" 0 multisig approve "$tx_id"
-    call_ledger "$(pem 2)" 0 multisig revoke "$tx_id"
-    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
+    call_ledger --pem=1 --port=8000 multisig approve "$tx_id"
+    call_ledger --pem=2 --port=8000 multisig revoke "$tx_id"
+    call_ledger --pem=1 --port=8000 multisig execute "$tx_id"
     assert_output --partial "This transaction cannot be executed yet."
 
-    call_ledger "$(pem 2)" 0 multisig approve "$tx_id"
-    call_ledger "$(pem 1)" 0 multisig execute "$tx_id"
+    call_ledger --pem=2 --port=8000 multisig approve "$tx_id"
+    call_ledger --pem=1 --port=8000 multisig execute "$tx_id"
 
-    check_consistency "$(pem 3)" 100 "$(pem 3)" 0
+    check_consistency --pem=3 --balance=100 --id="$(identity 3)" 8000
 }

--- a/tests/e2e/webauthn.bats
+++ b/tests/e2e/webauthn.bats
@@ -9,11 +9,11 @@ function assert_idstore() {
     local cred_id="$3"
     local key2cose="$4"
 
-    many_message --id=0 idstore.getFromRecallPhrase "$recall"
+    run many_message "$(pem 0)" idstore.getFromRecallPhrase "$recall"
     assert_output --partial "0: h'$(echo "$cred_id" | tr A-Z a-z)'"
     assert_output --partial "1: h'${key2cose}'"
 
-    many_message --id=0 idstore.getFromAddress '{0: "'"$identity"'"}'
+    run many_message "$(pem 0)" idstore.getFromAddress '{0: "'"$identity"'"}'
     assert_output --partial "0: h'$(echo "$cred_id" | tr A-Z a-z)'"
     assert_output --partial "1: h'${key2cose}'"
 }
@@ -43,7 +43,7 @@ function teardown() {
     cred_id=$(cred_id)
     key2cose=$(key2cose 1)
 
-    many_message --id=0 idstore.store "{0: 10000_1(h'${identity_hex}'), 1: h'${cred_id}', 2: h'${key2cose}'}"
+    run many_message "$(pem 0)" idstore.store "{0: 10000_1(h'${identity_hex}'), 1: h'${cred_id}', 2: h'${key2cose}'}"
     assert_output '{0: ["abandon", "again"]}'
 
     assert_idstore "$output" "$(identity 1)" "$cred_id" "$key2cose"
@@ -52,7 +52,7 @@ function teardown() {
 @test "$SUITE: IdStore store deny non-webauthn" {
     start_ledger --pem "$(pem 0)"
 
-    many_message --error --id=0 idstore.store "{0: 10000_1(h'$(identity_hex 1)'), 1: h'$(cred_id)', 2: h'$(key2cose 1)'}"
+    run many_message "$(pem 0)" idstore.store "{0: 10000_1(h'$(identity_hex 1)'), 1: h'$(cred_id)', 2: h'$(key2cose 1)'}"
     assert_output --partial "Non-WebAuthn request denied for endpoint"
 }
 
@@ -76,7 +76,7 @@ function teardown() {
     cred_id_1=$(cred_id)
     key2cose_1=$(key2cose 1)
 
-    many_message --id=0 idstore.store "{0: 10000_1(h'${identity_hex_1}'), 1: h'${cred_id_1}', 2: h'${key2cose_1}'}"
+    run many_message "$(pem 0)" idstore.store "{0: 10000_1(h'${identity_hex_1}'), 1: h'${cred_id_1}', 2: h'${key2cose_1}'}"
     assert_output '{0: ["abandon", "again"]}'
     local recall_1
     recall_1="$output"
@@ -108,7 +108,7 @@ function teardown() {
     key2cose_2=$(key2cose 2)
 
     # Continue the test.
-    many_message --id=0 idstore.store "{0: 10000_1(h'${identity_hex_2}'), 1: h'${cred_id_2}', 2: h'${key2cose_2}'}"
+    run many_message "$(pem 0)" idstore.store "{0: 10000_1(h'${identity_hex_2}'), 1: h'${cred_id_2}', 2: h'${key2cose_2}'}"
     assert_output '{0: ["abandon", "asset"]}'
     local recall_2
     recall_2="$output"

--- a/tests/e2e/webauthn.bats
+++ b/tests/e2e/webauthn.bats
@@ -9,11 +9,11 @@ function assert_idstore() {
     local cred_id="$3"
     local key2cose="$4"
 
-    run many_message "$(pem 0)" idstore.getFromRecallPhrase "$recall"
+    run many_message --pem=0 idstore.getFromRecallPhrase "$recall"
     assert_output --partial "0: h'$(echo "$cred_id" | tr A-Z a-z)'"
     assert_output --partial "1: h'${key2cose}'"
 
-    run many_message "$(pem 0)" idstore.getFromAddress '{0: "'"$identity"'"}'
+    run many_message --pem=0 idstore.getFromAddress '{0: "'"$identity"'"}'
     assert_output --partial "0: h'$(echo "$cred_id" | tr A-Z a-z)'"
     assert_output --partial "1: h'${key2cose}'"
 }
@@ -43,7 +43,7 @@ function teardown() {
     cred_id=$(cred_id)
     key2cose=$(key2cose 1)
 
-    run many_message "$(pem 0)" idstore.store "{0: 10000_1(h'${identity_hex}'), 1: h'${cred_id}', 2: h'${key2cose}'}"
+    run many_message --pem=0 idstore.store "{0: 10000_1(h'${identity_hex}'), 1: h'${cred_id}', 2: h'${key2cose}'}"
     assert_output '{0: ["abandon", "again"]}'
 
     assert_idstore "$output" "$(identity 1)" "$cred_id" "$key2cose"
@@ -52,7 +52,7 @@ function teardown() {
 @test "$SUITE: IdStore store deny non-webauthn" {
     start_ledger --pem "$(pem 0)"
 
-    run many_message "$(pem 0)" idstore.store "{0: 10000_1(h'$(identity_hex 1)'), 1: h'$(cred_id)', 2: h'$(key2cose 1)'}"
+    run many_message --pem=0 idstore.store "{0: 10000_1(h'$(identity_hex 1)'), 1: h'$(cred_id)', 2: h'$(key2cose 1)'}"
     assert_output --partial "Non-WebAuthn request denied for endpoint"
 }
 
@@ -76,7 +76,7 @@ function teardown() {
     cred_id_1=$(cred_id)
     key2cose_1=$(key2cose 1)
 
-    run many_message "$(pem 0)" idstore.store "{0: 10000_1(h'${identity_hex_1}'), 1: h'${cred_id_1}', 2: h'${key2cose_1}'}"
+    run many_message --pem=0 idstore.store "{0: 10000_1(h'${identity_hex_1}'), 1: h'${cred_id_1}', 2: h'${key2cose_1}'}"
     assert_output '{0: ["abandon", "again"]}'
     local recall_1
     recall_1="$output"
@@ -108,7 +108,7 @@ function teardown() {
     key2cose_2=$(key2cose 2)
 
     # Continue the test.
-    run many_message "$(pem 0)" idstore.store "{0: 10000_1(h'${identity_hex_2}'), 1: h'${cred_id_2}', 2: h'${key2cose_2}'}"
+    run many_message --pem=0 idstore.store "{0: 10000_1(h'${identity_hex_2}'), 1: h'${cred_id_2}', 2: h'${key2cose_2}'}"
     assert_output '{0: ["abandon", "asset"]}'
     local recall_2
     recall_2="$output"

--- a/tests/resiliency/catch-up.bats
+++ b/tests/resiliency/catch-up.bats
@@ -39,28 +39,28 @@ function teardown() {
 
 @test "$SUITE: Node can catch up" {
     # Check consistency with nodes [0, 2] up
-    check_consistency "$(pem 1)" 1000000 "$(pem 1)" 0 1 2
-    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    check_consistency "$(pem 1)" 999000 "$(pem 1)" 0 1 2
-    check_consistency "$(pem 2)" 1000 "$(pem 2)" 0 1 2
+    check_consistency --pem=1 --balance=1000000 --id="$(identity 1)" 8000 8001 8002
+    call_ledger --pem=1 --port=8000 send "$(identity 2)" 1000 MFX
+    check_consistency --pem=1 --balance=999000 --id="$(identity 1)" 8000 8001 8002
+    check_consistency --pem=2 --balance=1000 --id="$(identity 2)" 8000 8001 8002
 
-    call_ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
-    call_ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
-    check_consistency "$(pem 1)" 997000 "$(pem 1)" 0 1 2
-    check_consistency "$(pem 2)" 3000 "$(pem 2)" 0 1 2
+    call_ledger --pem=1 --port=8001 send "$(identity 2)" 1000 MFX
+    call_ledger --pem=1 --port=8001 send "$(identity 2)" 1000 MFX
+    check_consistency --pem=1 --balance=997000 --id="$(identity 1)" 8000 8001 8002
+    check_consistency --pem=2 --balance=3000 --id="$(identity 2)" 8000 8001 8002
 
-    call_ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
-    call_ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
-    call_ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
-    check_consistency "$(pem 1)" 994000 "$(pem 1)" 0 1 2
-    check_consistency "$(pem 2)" 6000 "$(pem 2)" 0 1 2
+    call_ledger --pem=1 --port=8002 send "$(identity 2)" 1000 MFX
+    call_ledger --pem=1 --port=8002 send "$(identity 2)" 1000 MFX
+    call_ledger --pem=1 --port=8002 send "$(identity 2)" 1000 MFX
+    check_consistency --pem=1 --balance=994000 --id="$(identity 1)" 8000 8001 8002
+    check_consistency --pem=2 --balance=6000 --id="$(identity 2)" 8000 8001 8002
 
-    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    check_consistency "$(pem 1)" 990000 "$(pem 1)" 0 1 2
-    check_consistency "$(pem 2)" 10000 "$(pem 2)" 0 1 2
+    call_ledger --pem=1 --port=8000 send "$(identity 2)" 1000 MFX
+    call_ledger --pem=1 --port=8000 send "$(identity 2)" 1000 MFX
+    call_ledger --pem=1 --port=8000 send "$(identity 2)" 1000 MFX
+    call_ledger --pem=1 --port=8000 send "$(identity 2)" 1000 MFX
+    check_consistency --pem=1 --balance=990000 --id="$(identity 1)" 8000 8001 8002
+    check_consistency --pem=2 --balance=10000 --id="$(identity 2)" 8000 8001 8002
 
     cd "$GIT_ROOT/docker/e2e/" || exit 1
 
@@ -80,6 +80,6 @@ function teardown() {
     done >/dev/null
 EOT
     sleep 12  # Three consensus round.
-    check_consistency "$(pem 1)" 990000 "$(pem 1)" 0 1 2 3
-    check_consistency "$(pem 2)" 10000 "$(pem 2)" 0 1 2 3
+    check_consistency --pem=1 --balance=990000 --id="$(identity 1)" 8000 8001 8002 8003
+    check_consistency --pem=2 --balance=10000 --id="$(identity 2)" 8000 8001 8002 8003
 }

--- a/tests/resiliency/catch-up.bats
+++ b/tests/resiliency/catch-up.bats
@@ -11,16 +11,12 @@ function setup() {
       make clean
       for i in {0..2}
       do
-          make start-single-node-background ID_WITH_BALANCES="$(identity 1):1000000:$MFX_ADDRESS" NODE="${i}" || {
+          make $(ciopt start-single-node-dettached)-${i} ABCI_TAG=$(img_tag) LEDGER_TAG=$(img_tag) ID_WITH_BALANCES="$(identity 1):1000000:$MFX_ADDRESS" || {
             echo Could not start nodes... >&3
             exit 1
           }
       done
     ) > /dev/null
-    (
-      cd "$GIT_ROOT" || exit 1
-      cargo build --all-features
-    )
 
     # Give time to the servers to start.
     sleep 30
@@ -36,56 +32,42 @@ function teardown() {
       cd "$GIT_ROOT/docker/e2e/" || exit 1
       make stop-nodes
     ) 2> /dev/null
-}
 
-function ledger() {
-    local pem="$1"
-    local port="$2"
-    shift 2
-    run "$GIT_ROOT/target/debug/ledger" --pem "$pem" "http://localhost:$((port + 8000))/" "$@"
-}
-
-function check_consistency() {
-    local pem="$1"
-    local expected_balance="$2"
-    shift 2
-
-    for port in "$@"; do
-        ledger "$pem" "$port" balance
-        assert_output --partial " $expected_balance MFX "
-    done
+    # Fix for BATS verbose run/test output gathering
+    cd "$GIT_ROOT/tests/resiliency/" || exit 1
 }
 
 @test "$SUITE: Node can catch up" {
     # Check consistency with nodes [0, 2] up
-    check_consistency "$(pem 1)" 1000000 0 1 2
-    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    check_consistency "$(pem 1)" 999000 0 1 2
-    check_consistency "$(pem 2)" 1000 0 1 2
+    check_consistency "$(pem 1)" 1000000 "$(pem 1)" 0 1 2
+    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    check_consistency "$(pem 1)" 999000 "$(pem 1)" 0 1 2
+    check_consistency "$(pem 2)" 1000 "$(pem 2)" 0 1 2
 
-    ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
-    ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
-    check_consistency "$(pem 1)" 997000 0 1 2
-    check_consistency "$(pem 2)" 3000 0 1 2
+    call_ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
+    call_ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
+    check_consistency "$(pem 1)" 997000 "$(pem 1)" 0 1 2
+    check_consistency "$(pem 2)" 3000 "$(pem 2)" 0 1 2
 
-    ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
-    ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
-    ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
-    check_consistency "$(pem 1)" 994000 0 1 2
-    check_consistency "$(pem 2)" 6000 0 1 2
+    call_ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
+    call_ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
+    call_ledger "$(pem 1)" 2 send "$(identity 2)" 1000 MFX
+    check_consistency "$(pem 1)" 994000 "$(pem 1)" 0 1 2
+    check_consistency "$(pem 2)" 6000 "$(pem 2)" 0 1 2
 
-    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    check_consistency "$(pem 1)" 990000 0 1 2
-    check_consistency "$(pem 2)" 10000 0 1 2
+    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    check_consistency "$(pem 1)" 990000 "$(pem 1)" 0 1 2
+    check_consistency "$(pem 2)" 10000 "$(pem 2)" 0 1 2
 
     cd "$GIT_ROOT/docker/e2e/" || exit 1
 
     sleep 300
+
     # At this point, start the 4th node and check it can catch up
-    make start-single-node-background ID_WITH_BALANCES="$(identity 1):1000000" NODE="3" || {
+    make $(ciopt start-single-node-dettached)-3 ABCI_TAG=$(img_tag) LEDGER_TAG=$(img_tag) ID_WITH_BALANCES="$(identity 1):1000000" || {
       echo Could not start nodes... >&3
       exit 1
     }
@@ -98,56 +80,6 @@ function check_consistency() {
     done >/dev/null
 EOT
     sleep 12  # Three consensus round.
-    check_consistency "$(pem 1)" 990000 0 1 2 3
-    check_consistency "$(pem 2)" 10000 0 1 2 3
-}
-
-@test "$SUITE: Node can catch up messages older than MANY timeout" {
-    # Check consistency with nodes [0, 2] up
-    check_consistency "$(pem 1)" 1000000 0 1 2
-    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
-    sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 999000 0 1 2
-    check_consistency "$(pem 2)" 1000 0 1 2
-
-    # Send a message that's 10 seconds off of being time out.
-    many message --timestamp $(($(date +%s) - (4 * 60 + 50))) --server http://localhost:8001 --pem "$(pem 1)" ledger.send '{
-        0: "'"$(identity 1)"'",
-        1: "'"$(identity 2)"'",
-        2: 1000,
-        3: "'"$MFX_ADDRESS"'",
-    }'
-    sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 998000 0 1 2
-    check_consistency "$(pem 2)" 2000 0 1 2
-
-    ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
-    ledger "$(pem 1)" 1 send "$(identity 2)" 1000 MFX
-    sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 996000 0 1 2
-    check_consistency "$(pem 2)" 4000 0 1 2
-
-    cd "$GIT_ROOT/docker/e2e/" || exit 1
-
-    # Wait long enough to invalidate the first manual transaction.
-    # Since we already waited 4 seconds twice above, we really just need to wait a few more.
-    sleep 303
-
-    # At this point, start the 4th node and check it can catch up
-    make start-single-node-background ID_WITH_BALANCES="$(identity 1):1000000:$MFX_ADDRESS" NODE="3" || {
-      echo Could not start nodes... >&3
-      exit 1
-    }
-
-    # Give the 4th node some time to boot
-    sleep 30
-    timeout 60s bash <<EOT
-    while ! many message --server http://localhost:8003 status; do
-      sleep 1
-    done >/dev/null
-EOT
-
-    sleep 10  # Give some time to catch up.
-    check_consistency "$(pem 1)" 996000 0 1 2 3
-    check_consistency "$(pem 2)" 4000 0 1 2 3
+    check_consistency "$(pem 1)" 990000 "$(pem 1)" 0 1 2 3
+    check_consistency "$(pem 2)" 10000 "$(pem 2)" 0 1 2 3
 }

--- a/tests/resiliency/up-down.bats
+++ b/tests/resiliency/up-down.bats
@@ -8,15 +8,11 @@ function setup() {
     (
       cd "$GIT_ROOT/docker/e2e/" || exit
       make clean
-      make start-nodes-background ID_WITH_BALANCES="$(identity 1):1000000" || {
+      make $(ciopt start-nodes-dettached) ABCI_TAG=$(img_tag) LEDGER_TAG=$(img_tag) ID_WITH_BALANCES="$(identity 1):1000000" || {
         echo Could not start nodes... >&3
         exit 1
       }
     ) > /dev/null
-    (
-      cd "$GIT_ROOT" || exit 1
-      cargo build --all-features
-    )
 
     # Give time to the servers to start.
     sleep 30
@@ -32,74 +28,71 @@ function teardown() {
       cd "$GIT_ROOT/docker/e2e/" || exit 1
       make stop-nodes
     ) 2> /dev/null
-}
 
-function ledger() {
-    local pem="$1"
-    local port="$2"
-    shift 2
-    run "$GIT_ROOT/target/debug/ledger" --pem "$pem" "http://localhost:$((port + 8000))/" "$@"
-}
-
-function check_consistency() {
-    local pem="$1"
-    local expected_balance="$2"
-    shift 2
-
-    for port in "$@"; do
-        ledger "$pem" "$port" balance
-        assert_output --partial " $expected_balance MFX "
-    done
+    # Fix for BATS verbose run/test output gathering
+    cd "$GIT_ROOT/tests/resiliency/" || exit 1
 }
 
 @test "$SUITE: Network is consistent" {
     # Check consistency with all nodes up.
-    check_consistency "$(pem 1)" 1000000 0 1 2 3
-    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    check_consistency "$(pem 1)" 1000000 "$(pem 1)" 0 1 2 3
+    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
     sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 999000 0 1 2 3
-    check_consistency "$(pem 2)" 1000 0 1 2 3
+    check_consistency "$(pem 1)" 999000 "$(pem 1)" 0 1 2 3
+    check_consistency "$(pem 2)" 1000 "$(pem 2)" 0 1 2 3
 
-    ledger "$(pem 1)" 1 send "$(identity 2)" 2000 MFX
+    call_ledger "$(pem 1)" 1 send "$(identity 2)" 2000 MFX
     sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 997000 0 1 2 3
-    check_consistency "$(pem 2)" 3000 0 1 2 3
+    check_consistency "$(pem 1)" 997000 "$(pem 1)" 0 1 2 3
+    check_consistency "$(pem 2)" 3000 "$(pem 2)" 0 1 2 3
 
-    ledger "$(pem 1)" 2 send "$(identity 2)" 3000 MFX
+    call_ledger "$(pem 1)" 2 send "$(identity 2)" 3000 MFX
     sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 994000 0 1 2 3
-    check_consistency "$(pem 2)" 6000 0 1 2 3
+    check_consistency "$(pem 1)" 994000 "$(pem 1)" 0 1 2 3
+    check_consistency "$(pem 2)" 6000 "$(pem 2)" 0 1 2 3
 
-    ledger "$(pem 1)" 3 send "$(identity 2)" 4000 MFX
+    call_ledger "$(pem 1)" 3 send "$(identity 2)" 4000 MFX
     sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 990000 0 1 2 3
-    check_consistency "$(pem 2)" 10000 0 1 2 3
+    check_consistency "$(pem 1)" 990000 "$(pem 1)" 0 1 2 3
+    check_consistency "$(pem 2)" 10000 "$(pem 2)" 0 1 2 3
 }
 
 @test "$SUITE: Network is consistent with 1 node down" {
+    cd "$GIT_ROOT/docker/e2e/" || exit 1
+
     # Bring down node 3.
-    docker stop e2e-tendermint-3-1
+    make stop-single-node-3
 
     # Check consistency with all nodes up.
-    check_consistency "$(pem 1)" 1000000 0 1 2
-    ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    check_consistency "$(pem 1)" 1000000 "$(pem 1)" 0 1 2
+    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
     sleep 10  # One consensus round.
-    check_consistency "$(pem 1)" 999000 0 1 2
-    check_consistency "$(pem 2)" 1000 0 1 2
+    check_consistency "$(pem 1)" 999000 "$(pem 1)" 0 1 2
+    check_consistency "$(pem 2)" 1000 "$(pem 2)" 0 1 2
 
-    ledger "$(pem 1)" 1 send "$(identity 2)" 2000 MFX
+    call_ledger "$(pem 1)" 1 send "$(identity 2)" 2000 MFX
     sleep 10  # One consensus round.
-    check_consistency "$(pem 1)" 997000 0 1 2
-    check_consistency "$(pem 2)" 3000 0 1 2
+    check_consistency "$(pem 1)" 997000 "$(pem 1)" 0 1 2
+    check_consistency "$(pem 2)" 3000 "$(pem 2)" 0 1 2
 
-    ledger "$(pem 1)" 2 send "$(identity 2)" 3000 MFX
+    call_ledger "$(pem 1)" 2 send "$(identity 2)" 3000 MFX
     sleep 10  # One consensus round.
-    check_consistency "$(pem 1)" 994000 0 1 2
-    check_consistency "$(pem 2)" 6000 0 1 2
+    check_consistency "$(pem 1)" 994000 "$(pem 1)" 0 1 2
+    check_consistency "$(pem 2)" 6000 "$(pem 2)" 0 1 2
 
     # Bring it back.
-    docker start e2e-tendermint-3-1
+    make $(ciopt start-single-node-dettached)-3 ABCI_TAG=$(img_tag) LEDGER_TAG=$(img_tag) || {
+        echo Could not start nodes... >&3
+        exit 1
+    }
+
+    # Give time to the servers to start.
+    timeout 60s bash <<EOT
+    while ! many message --server http://localhost:8003 status; do
+      sleep 1
+    done >/dev/null
+EOT
     sleep 10
-    check_consistency "$(pem 1)" 994000 0 1 2 3
-    check_consistency "$(pem 2)" 6000 0 1 2 3
+    check_consistency "$(pem 1)" 994000 "$(pem 1)" 0 1 2 3
+    check_consistency "$(pem 2)" 6000 "$(pem 2)" 0 1 2 3
 }

--- a/tests/resiliency/up-down.bats
+++ b/tests/resiliency/up-down.bats
@@ -35,26 +35,26 @@ function teardown() {
 
 @test "$SUITE: Network is consistent" {
     # Check consistency with all nodes up.
-    check_consistency "$(pem 1)" 1000000 "$(pem 1)" 0 1 2 3
-    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    check_consistency --pem=1 --balance=1000000 --id="$(identity 1)" 8000 8001 8002 8003
+    call_ledger --pem=1 --port=8000 send "$(identity 2)" 1000 MFX
     sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 999000 "$(pem 1)" 0 1 2 3
-    check_consistency "$(pem 2)" 1000 "$(pem 2)" 0 1 2 3
+    check_consistency --pem=1 --balance=999000 --id="$(identity 1)" 8000 8001 8002 8003
+    check_consistency --pem=2 --balance=1000 --id="$(identity 2)" 8000 8001 8002 8003
 
-    call_ledger "$(pem 1)" 1 send "$(identity 2)" 2000 MFX
+    call_ledger --pem=1 --port=8001 send "$(identity 2)" 2000 MFX
     sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 997000 "$(pem 1)" 0 1 2 3
-    check_consistency "$(pem 2)" 3000 "$(pem 2)" 0 1 2 3
+    check_consistency --pem=1 --balance=997000 --id="$(identity 1)" 8000 8001 8002 8003
+    check_consistency --pem=2 --balance=3000 --id="$(identity 2)" 8000 8001 8002 8003
 
-    call_ledger "$(pem 1)" 2 send "$(identity 2)" 3000 MFX
+    call_ledger --pem=1 --port=8002 send "$(identity 2)" 3000 MFX
     sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 994000 "$(pem 1)" 0 1 2 3
-    check_consistency "$(pem 2)" 6000 "$(pem 2)" 0 1 2 3
+    check_consistency --pem=1 --balance=994000 --id="$(identity 1)" 8000 8001 8002 8003
+    check_consistency --pem=2 --balance=6000 --id="$(identity 2)" 8000 8001 8002 8003
 
-    call_ledger "$(pem 1)" 3 send "$(identity 2)" 4000 MFX
+    call_ledger --pem=1 --port=8003 send "$(identity 2)" 4000 MFX
     sleep 4  # One consensus round.
-    check_consistency "$(pem 1)" 990000 "$(pem 1)" 0 1 2 3
-    check_consistency "$(pem 2)" 10000 "$(pem 2)" 0 1 2 3
+    check_consistency --pem=1 --balance=990000 --id="$(identity 1)" 8000 8001 8002 8003
+    check_consistency --pem=2 --balance=10000 --id="$(identity 2)" 8000 8001 8002 8003
 }
 
 @test "$SUITE: Network is consistent with 1 node down" {
@@ -64,21 +64,21 @@ function teardown() {
     make stop-single-node-3
 
     # Check consistency with all nodes up.
-    check_consistency "$(pem 1)" 1000000 "$(pem 1)" 0 1 2
-    call_ledger "$(pem 1)" 0 send "$(identity 2)" 1000 MFX
+    check_consistency --pem=1 --balance=1000000 --id="$(identity 1)" 8000 8001 8002
+    call_ledger --pem=1 --port=8000 send "$(identity 2)" 1000 MFX
     sleep 10  # One consensus round.
-    check_consistency "$(pem 1)" 999000 "$(pem 1)" 0 1 2
-    check_consistency "$(pem 2)" 1000 "$(pem 2)" 0 1 2
+    check_consistency --pem=1 --balance=999000 --id="$(identity 1)" 8000 8001 8002
+    check_consistency --pem=2 --balance=1000 --id="$(identity 2)" 8000 8001 8002
 
-    call_ledger "$(pem 1)" 1 send "$(identity 2)" 2000 MFX
+    call_ledger --pem=1 --port=8001 send "$(identity 2)" 2000 MFX
     sleep 10  # One consensus round.
-    check_consistency "$(pem 1)" 997000 "$(pem 1)" 0 1 2
-    check_consistency "$(pem 2)" 3000 "$(pem 2)" 0 1 2
+    check_consistency --pem=1 --balance=997000 --id="$(identity 1)" 8000 8001 8002
+    check_consistency --pem=2 --balance=3000 --id="$(identity 2)" 8000 8001 8002
 
-    call_ledger "$(pem 1)" 2 send "$(identity 2)" 3000 MFX
+    call_ledger --pem=1 --port=8002 send "$(identity 2)" 3000 MFX
     sleep 10  # One consensus round.
-    check_consistency "$(pem 1)" 994000 "$(pem 1)" 0 1 2
-    check_consistency "$(pem 2)" 6000 "$(pem 2)" 0 1 2
+    check_consistency --pem=1 --balance=994000 --id="$(identity 1)" 8000 8001 8002
+    check_consistency --pem=2 --balance=6000 --id="$(identity 2)" 8000 8001 8002
 
     # Bring it back.
     make $(ciopt start-single-node-dettached)-3 ABCI_TAG=$(img_tag) LEDGER_TAG=$(img_tag) || {
@@ -93,6 +93,6 @@ function teardown() {
     done >/dev/null
 EOT
     sleep 10
-    check_consistency "$(pem 1)" 994000 "$(pem 1)" 0 1 2 3
-    check_consistency "$(pem 2)" 6000 "$(pem 2)" 0 1 2 3
+    check_consistency --pem=1 --balance=994000 --id="$(identity 1)" 8000 8001 8002 8003
+    check_consistency --pem=2 --balance=6000 --id="$(identity 2)" 8000 8001 8002 8003
 }

--- a/tests/test_helper/ledger.bash
+++ b/tests/test_helper/ledger.bash
@@ -1,44 +1,40 @@
 PEM_ROOT="$(mktemp -d)"
 
-function ledger() {
-    local pem_arg
-    local error
-    local check_balance
+# Do not rename this function `ledger`.
+# It clashes with the call to the `ledger` binary on CI
+function call_ledger() {
+    local pem="$1"
+    local port="$2"
+    shift 2
 
-    while (( $# > 0 )); do
-      case "$1" in
-        --id=*) pem_arg="--pem=$(pem "${1#--id=}")"; shift ;;
-        -e|--error) error=1; shift ;;
-        --balance=*) check_balance="${1#--balance=}"; shift ;;
-        --) shift; break ;;
-        *) break ;;
-      esac
+    local ledgercmd
+    [[ "$CI" == "true" ]]\
+      && ledgercmd="ledger" \
+      || ledgercmd="$GIT_ROOT/target/debug/ledger"
+
+    echo "${ledgercmd}" --pem "${pem}" "http://localhost:$((port + 8000))/" "$@" >&2
+    run "${ledgercmd}" --pem "${pem}" "http://localhost:$((port + 8000))/" "$@"
+}
+
+function check_consistency() {
+    local pem="$1"
+    local expected_balance="$2"
+    local id_arg="$3"
+    shift 3
+
+    for port in "$@"; do
+        call_ledger "$pem" "$port" balance "$id_arg"
+        assert_output --partial "$expected_balance MFX "
     done
-
-    echo ../../target/debug/ledger "$pem_arg" "http://localhost:8000/" "$@" >&2
-    run ../../target/debug/ledger "$pem_arg" "http://localhost:8000/" "$@"
-    if [ "$error" ]; then
-      [ "$status" -ne 0 ]
-    else
-      [ "$status" -eq 0 ]
-      if [ "$check_balance" ]; then
-        assert_output --partial "${check_balance} MFX"
-      fi
-    fi
 }
 
 function account_create() {
-    local id_arg
+    local pem="$1"
+    shift
 
-    while (( $# > 0 )); do
-      case "$1" in
-        --id=*) id_arg="$1"; shift ;;
-        --) shift; break ;;
-        *) break ;;
-      esac
-    done
-
-    many_message "$id_arg" account.create "$@"
-    account_id="$(echo "$output" | grep -o "h'[0-9a-z]*'" | grep -oE "[0-9a-z][0-9a-z]+")"
-    command many id "$account_id"
+    account_id="$(many_message "$pem" account.create "$@" | grep -o "h'[0-9a-z]*'" | grep -oE "[0-9a-z][0-9a-z]+")"
+    account_many_id=$(many id "$account_id")
+    assert [ "${account_many_id::1}" = "m" ]  # Check the account ID starts with an "m"
+    assert [ ${#account_many_id} -eq 55 ]     # Check the account ID has the right length
+    echo "${account_many_id}"
 }

--- a/tests/test_helper/ledger.bash
+++ b/tests/test_helper/ledger.bash
@@ -3,36 +3,59 @@ PEM_ROOT="$(mktemp -d)"
 # Do not rename this function `ledger`.
 # It clashes with the call to the `ledger` binary on CI
 function call_ledger() {
-    local pem="$1"
-    local port="$2"
-    shift 2
+    local pem_arg
+    local port
+
+    while (( $# > 0 )); do
+      case "$1" in
+        --pem=*) pem_arg="--pem=$(pem "${1#--pem=}")"; shift ;;
+        --port=*) port=${1#--port=}; shift ;;
+        --) shift; break ;;
+        *) break ;;
+      esac
+    done
 
     local ledgercmd
     [[ "$CI" == "true" ]]\
       && ledgercmd="ledger" \
       || ledgercmd="$GIT_ROOT/target/debug/ledger"
 
-    echo "${ledgercmd}" --pem "${pem}" "http://localhost:$((port + 8000))/" "$@" >&2
-    run "${ledgercmd}" --pem "${pem}" "http://localhost:$((port + 8000))/" "$@"
+    echo "${ledgercmd}" "$pem_arg" "http://localhost:${port}/" "$@" >&2
+    run "${ledgercmd}" "$pem_arg" "http://localhost:${port}/" "$@"
 }
 
 function check_consistency() {
-    local pem="$1"
-    local expected_balance="$2"
-    local id_arg="$3"
-    shift 3
+    local pem
+    local expected_balance
+    local id
+
+    while (( $# > 0 )); do
+      case "$1" in
+        --pem=*) pem=${1#--pem=}; shift ;;
+        --balance=*) expected_balance=${1#--balance=}; shift;;
+        --id=*) id=${1#--id=}; shift ;;
+        --) shift; break ;;
+        *) break ;;
+      esac
+    done
 
     for port in "$@"; do
-        call_ledger "$pem" "$port" balance "$id_arg"
+        call_ledger --pem="$pem" --port="$port" balance "$id"
         assert_output --partial "$expected_balance MFX "
     done
 }
 
 function account_create() {
-    local pem="$1"
-    shift
+    local pem_arg
+    while (( $# > 0 )); do
+      case "$1" in
+        --pem=*) pem_arg="${1}"; shift ;;
+        --) shift; break ;;
+        *) break ;;
+      esac
+    done
 
-    account_id="$(many_message "$pem" account.create "$@" | grep -o "h'[0-9a-z]*'" | grep -oE "[0-9a-z][0-9a-z]+")"
+    account_id="$(many_message "$pem_arg" account.create "$@" | grep -o "h'[0-9a-z]*'" | grep -oE "[0-9a-z][0-9a-z]+")"
     account_many_id=$(many id "$account_id")
     assert [ "${account_many_id::1}" = "m" ]  # Check the account ID starts with an "m"
     assert [ ${#account_many_id} -eq 55 ]     # Check the account ID has the right length

--- a/tests/test_helper/load.bash
+++ b/tests/test_helper/load.bash
@@ -1,5 +1,21 @@
 function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
 
+# Do not regen Docker images on CI.
+# Docker images will be pulled by CI.
+function ciopt() {
+    [[ "$CI" == "true" ]]\
+      && echo ${1}-no-img-regen \
+      || echo ${1}
+}
+
+# Use the nightly Docker image when running the tests on CI.
+# Use the latest Docker image when running the tests locally.
+function img_tag {
+    [[ "$CI" == "true" ]]\
+      && echo "nightly" \
+      || echo "latest"
+}
+
 source "$(dirname "${BASH_SOURCE[0]}")/bats-assert/load.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/bats-support/load.bash"
 

--- a/tests/test_helper/many.bash
+++ b/tests/test_helper/many.bash
@@ -47,24 +47,10 @@ function cred_id() {
 }
 
 function many_message() {
-    local pem_arg
-    local error
+    local pem="$1"
+    shift
 
-    while (( $# > 0 )); do
-      case "$1" in
-        --id=*) pem_arg="--pem=$(pem ${1#--id=})"; shift ;;
-        -e|--error) error=1; shift ;;
-        --) shift; break ;;
-        *) break ;;
-      esac
-    done
-
-    run command many message --server http://localhost:8000 "$pem_arg" "$@"
-    if [ "$error" ]; then
-      [ "$status" -ne 0 ]
-    else
-      [ "$status" -eq 0 ]
-    fi
+    command many message --pem "$pem" --server http://localhost:8000 "$@"
 }
 
 function identity() {

--- a/tests/test_helper/many.bash
+++ b/tests/test_helper/many.bash
@@ -47,10 +47,17 @@ function cred_id() {
 }
 
 function many_message() {
-    local pem="$1"
-    shift
+    local pem_arg
 
-    command many message --pem "$pem" --server http://localhost:8000 "$@"
+    while (( $# > 0 )); do
+       case "$1" in
+         --pem=*) pem_arg="--pem=$(pem ${1#--pem=})"; shift ;;
+         --) shift; break ;;
+         *) break ;;
+       esac
+     done
+
+    command many message "$pem_arg" --server http://localhost:8000 "$@"
 }
 
 function identity() {


### PR DESCRIPTION
- Nightly Docker images and resiliency tests run
- Add support for Docker image tags other than `latest`
- Refactor/cleanup BATs tests and utilities
- Use `lifted` DockerHub org
- Other fixes and cleanup

Successful run example available at https://app.circleci.com/pipelines/github/fmorency/many-framework/26/workflows/26d27a5b-8e77-4dcd-9a66-e6b71939dfe2

**IMPORTANT @hansl IMPORTANT**
Needed before merging this PR:
* DockerHub machine builder user (ll-docker) with RW rights to the lifted DockerHub org
  * I tested using my user
* DOCKER_CREDS CircleCI Context with
  * DOCKER_LOGIN
  * DOCKER_PASSWORD
* A nightly trigger named “Nightly Docker and Resiliency Tests”