### PR TITLE
Revert "Update many-rs to latest"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.63"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "arrayref"
@@ -58,25 +58,6 @@ checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
 
 [[package]]
 name = "asn1"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfffb35195feaeffb071af0f7a643405667813dd8629c27cb0c310fb76654ab1"
-dependencies = [
- "chrono",
-]
-
-[[package]]
-name = "asn1"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cc1ec17f6a9d5054651c433a7dacfbf7fd68ae6a91b550e2461b25d3cb6c3d"
-dependencies = [
- "asn1_derive",
- "chrono",
-]
-
-[[package]]
-name = "asn1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0959d3f3489cab2f24b15d637451fe3e8a6b3bfe6bd5ebbc8080fa931a77d3"
@@ -85,21 +66,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "asn1_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07c097e3b2b4bedbf78a75bb1251c25d050d6db3bcb6b415fc0d28b824a6163"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-channel"
-version = "1.7.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -122,23 +92,21 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "1.6.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+checksum = "8b3ca4f8ff117c37c278a2f7415ce9be55560b846b5bc4412aaa5d29c1c3dae2"
 dependencies = [
  "async-lock",
- "autocfg",
  "blocking",
  "futures-lite",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.9.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
+checksum = "e5e18f61464ae81cde0a23e713ae8fd299580c54d697a35820cfd0625b8b0e07"
 dependencies = [
- "autocfg",
  "concurrent-queue",
  "futures-lite",
  "libc",
@@ -163,24 +131,22 @@ dependencies = [
 
 [[package]]
 name = "async-net"
-version = "1.7.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4051e67316bc7eff608fe723df5d32ed639946adcd69e07df41fd42a7b411f1f"
+checksum = "5373304df79b9b4395068fb080369ec7178608827306ce4d081cba51cac551df"
 dependencies = [
  "async-io",
- "autocfg",
  "blocking",
  "futures-lite",
 ]
 
 [[package]]
 name = "async-process"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
+checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
 dependencies = [
  "async-io",
- "autocfg",
  "blocking",
  "cfg-if 1.0.0",
  "event-listener",
@@ -199,9 +165,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -350,12 +316,24 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding 0.1.5",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
- "generic-array",
+ "block-padding 0.2.1",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -364,7 +342,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -373,8 +351,17 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
 dependencies = [
- "block-padding",
+ "block-padding 0.2.1",
  "cipher",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -399,15 +386,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+checksum = "a5377c8865e74a160d21f29c2d40669f53286db6eab59b88540cbb12ffc8b835"
 
 [[package]]
 name = "byteorder"
@@ -417,9 +410,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 dependencies = [
  "serde",
 ]
@@ -508,7 +501,7 @@ version = "0.2.0"
 source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
 dependencies = [
  "ciborium-io",
- "half 1.8.2",
+ "half",
 ]
 
 [[package]]
@@ -517,7 +510,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -548,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.19"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
 dependencies = [
  "atty",
  "bitflags",
@@ -565,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -598,18 +591,18 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.4"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
 ]
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -664,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -681,18 +674,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto-bigint"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
@@ -704,7 +691,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "typenum",
 ]
 
@@ -714,7 +701,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -724,7 +711,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -742,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "cryptoki-sys"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4895bb04269df9a14f2692c6499dc2769e9a93caa33ef37c4df134f76956d2"
+checksum = "aec220169d3b1705b54bce57e459873828e5c3bf0e25b96e5f2142acbbb71dda"
 dependencies = [
  "bindgen 0.59.2",
  "libloading",
@@ -962,11 +949,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -1050,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "elliptic-curve"
@@ -1062,7 +1058,7 @@ checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
  "crypto-bigint",
  "ff",
- "generic-array",
+ "generic-array 0.14.5",
  "group",
  "pkcs8 0.7.6",
  "rand_core 0.6.3",
@@ -1087,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
 dependencies = [
  "enum-iterator-derive",
 ]
@@ -1120,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "eyre"
@@ -1133,6 +1129,12 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
@@ -1155,13 +1157,13 @@ dependencies = [
 
 [[package]]
 name = "fixed"
-version = "1.19.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0371cd413fb63f8ec1b9eb4dff47fa2c88b21abc681771234c84808b9920991"
+checksum = "1e50e12d082af9f49314ae850d33c7e89bbe1b3f30857f747f7bed0750b068c5"
 dependencies = [
  "az",
  "bytemuck",
- "half 2.1.0",
+ "half",
  "typenum",
 ]
 
@@ -1208,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1223,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1233,15 +1235,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1250,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -1271,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1282,21 +1284,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1312,9 +1314,18 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -1388,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -1412,15 +1423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
-name = "half"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,7 +1441,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha-1",
+ "sha-1 0.10.0",
 ]
 
 [[package]]
@@ -1517,11 +1519,10 @@ dependencies = [
 name = "http_proxy"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.19",
+ "clap 3.2.15",
  "hex",
  "many-client",
  "many-identity",
- "many-identity-dsa",
  "many-kvstore",
  "many-modules",
  "minicbor",
@@ -1535,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
 
 [[package]]
 name = "httpdate"
@@ -1647,7 +1648,7 @@ name = "idstore-export"
 version = "0.1.0"
 dependencies = [
  "base64 0.20.0-alpha.1",
- "clap 3.2.19",
+ "clap 3.2.15",
  "merk",
  "serde",
  "serde_derive",
@@ -1714,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jobserver"
@@ -1757,12 +1758,11 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 name = "kvstore"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.19",
+ "clap 3.2.15",
  "hex",
  "many-client",
  "many-error",
  "many-identity",
- "many-identity-dsa",
  "many-kvstore",
  "many-modules",
  "minicbor",
@@ -1788,7 +1788,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 name = "ledger"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.19",
+ "clap 3.2.15",
  "crc-any",
  "hex",
  "humantime",
@@ -1797,8 +1797,6 @@ dependencies = [
  "many-client",
  "many-error",
  "many-identity",
- "many-identity-dsa",
- "many-identity-hsm",
  "many-modules",
  "many-protocol",
  "many-types",
@@ -1815,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgit2-sys"
@@ -1869,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1892,22 +1890,20 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "ciborium",
- "clap 3.2.19",
+ "clap 3.2.15",
  "coset",
  "hex",
  "lazy_static",
  "many-client",
  "many-error",
  "many-identity",
- "many-identity-dsa",
- "many-identity-webauthn",
  "many-modules",
  "many-protocol",
  "many-server",
  "many-types",
  "minicbor",
  "reqwest",
- "sha2 0.10.3",
+ "sha2 0.10.2",
  "signal-hook",
  "smol",
  "tendermint",
@@ -1923,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1#c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1938,13 +1934,10 @@ dependencies = [
  "fixed",
  "hex",
  "lazy_static",
- "many-client-macros",
  "many-identity",
- "many-identity-dsa",
  "many-modules",
  "many-protocol",
  "many-server",
- "many-types",
  "minicbor",
  "num-bigint",
  "num-derive",
@@ -1964,19 +1957,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "many-client-macros"
-version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1#c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -1987,9 +1970,9 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1#c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1"
 dependencies = [
- "asn1 0.11.0",
+ "asn1",
  "base32",
  "coset",
  "crc-any",
@@ -2004,77 +1987,10 @@ dependencies = [
  "pkcs8 0.8.0",
  "rand 0.7.3",
  "serde",
- "sha2 0.10.3",
- "sha3 0.10.2",
+ "sha2 0.10.2",
+ "sha3 0.10.1",
  "signature",
  "static_assertions",
- "tracing",
-]
-
-[[package]]
-name = "many-identity-dsa"
-version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
-dependencies = [
- "asn1 0.8.7",
- "base32",
- "coset",
- "crc-any",
- "cryptoki",
- "ed25519",
- "ed25519-dalek",
- "hex",
- "many-error",
- "many-identity",
- "minicbor",
- "once_cell",
- "p256",
- "pkcs8 0.8.0",
- "rand 0.7.3",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.3",
- "sha3 0.10.2",
- "signature",
- "tracing",
-]
-
-[[package]]
-name = "many-identity-hsm"
-version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
-dependencies = [
- "asn1 0.10.0",
- "coset",
- "cryptoki",
- "hex",
- "many-error",
- "many-identity",
- "many-identity-dsa",
- "many-protocol",
- "once_cell",
- "p256",
- "sha2 0.10.3",
- "signature",
- "tracing",
-]
-
-[[package]]
-name = "many-identity-webauthn"
-version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
-dependencies = [
- "base64 0.13.0",
- "coset",
- "many-error",
- "many-identity",
- "many-identity-dsa",
- "many-protocol",
- "minicbor",
- "once_cell",
- "serde",
- "serde_json",
- "sha2 0.10.3",
  "tracing",
 ]
 
@@ -2083,14 +1999,13 @@ name = "many-kvstore"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "clap 3.2.19",
+ "clap 3.2.15",
  "hex",
  "itertools",
  "lazy_static",
  "many-abci",
  "many-error",
  "many-identity",
- "many-identity-dsa",
  "many-modules",
  "many-protocol",
  "many-server",
@@ -2114,7 +2029,7 @@ dependencies = [
  "async-trait",
  "base64 0.20.0-alpha.1",
  "bip39-dict",
- "clap 3.2.19",
+ "clap 3.2.15",
  "coset",
  "fixed",
  "hex",
@@ -2125,8 +2040,6 @@ dependencies = [
  "many-client",
  "many-error",
  "many-identity",
- "many-identity-dsa",
- "many-identity-webauthn",
  "many-ledger",
  "many-modules",
  "many-protocol",
@@ -2156,7 +2069,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1#c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2169,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1#c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1"
 dependencies = [
  "async-trait",
  "coset",
@@ -2189,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1#c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1"
 dependencies = [
  "base64 0.13.0",
  "coset",
@@ -2206,7 +2119,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.3",
+ "sha2 0.10.2",
  "signature",
  "tracing",
 ]
@@ -2214,10 +2127,10 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1#c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1"
 dependencies = [
  "anyhow",
- "asn1 0.11.0",
+ "asn1",
  "async-trait",
  "base32",
  "base64 0.13.0",
@@ -2249,7 +2162,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.3",
+ "sha2 0.10.2",
  "sha3 0.9.1",
  "signature",
  "static_assertions",
@@ -2263,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=647b729969d358198e80464b95a42ee58a203891#647b729969d358198e80464b95a42ee58a203891"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1#c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1"
 dependencies = [
  "coset",
  "fixed",
@@ -2276,6 +2189,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
@@ -2317,7 +2236,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a20020e8e2d1881d8736f64011bb5ff99f1db9947ce3089706945c8915695cb"
 dependencies = [
- "half 1.8.2",
+ "half",
  "minicbor-derive",
 ]
 
@@ -2465,9 +2384,15 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -2522,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "p256"
@@ -2568,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pbkdf2"
@@ -2649,19 +2574,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
-version = "2.3.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
- "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2669,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2682,29 +2606,29 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.3.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
- "once_cell",
+ "maplit",
  "pest",
- "sha-1",
+ "sha-1 0.8.2",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2772,11 +2696,10 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polling"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "libc",
  "log",
@@ -2816,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2890,9 +2813,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -2979,9 +2902,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
 dependencies = [
  "bitflags",
 ]
@@ -3143,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "rusty-fork"
@@ -3161,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "salsa20"
@@ -3208,7 +3131,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.10.1",
  "salsa20",
- "sha2 0.10.3",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -3223,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3246,33 +3169,33 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3281,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
@@ -3292,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3326,6 +3249,18 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
@@ -3345,14 +3280,14 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -3368,14 +3303,14 @@ dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
  "keccak",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
 dependencies = [
  "digest 0.10.3",
  "keccak",
@@ -3472,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -3531,9 +3466,9 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3565,9 +3500,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3588,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.1"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621609553b14bca49448b3c97e625d7187980cc2a42fd169b4c3b306dcc4a7e9"
+checksum = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -3764,18 +3699,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.33"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.33"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3793,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.14"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa",
  "libc",
@@ -3921,9 +3856,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -3944,9 +3879,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4022,9 +3957,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
@@ -4091,9 +4026,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.4.2"
+version = "7.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+checksum = "3bbc4fafd30514504c7593cfa52eaf4d6c4ef660386e2ec54edc17f14aa08e8d"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4267,13 +4202,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.3.0"
+version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
 dependencies = [
  "either",
+ "lazy_static",
  "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/src/http_proxy/Cargo.toml
+++ b/src/http_proxy/Cargo.toml
@@ -19,11 +19,10 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["ed25519", "ecdsa"] }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
 many-kvstore = { path = "../many-kvstore" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
 new_mime_guess = "4.0.0"
 tiny_http = "0.11.0"
 tracing = "0.1.29"

--- a/src/kvstore/Cargo.toml
+++ b/src/kvstore/Cargo.toml
@@ -19,11 +19,10 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["ed25519", "ecdsa"] }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
 many-kvstore = { path = "../many-kvstore" }
 tracing = "0.1.29"
 tracing-subscriber = "0.3"

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -24,14 +24,12 @@ indicatif = "0.16.2"
 lazy_static = "1.4.0"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
 num-bigint = "0.4.3"
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["ed25519", "ecdsa"] }
-many-identity-hsm = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
 regex = "1.5.4"
 ring = "0.17.0-alpha.10"
 rpassword = "6.0"

--- a/src/ledger/src/multisig.rs
+++ b/src/ledger/src/multisig.rs
@@ -2,7 +2,7 @@ use crate::TargetCommandOpt;
 use clap::Parser;
 use many_client::ManyClient;
 use many_error::ManyError;
-use many_identity::{Address, Identity};
+use many_identity::Address;
 use many_modules::account::features::multisig;
 use many_modules::{events, ledger};
 use many_protocol::ResponseMessage;
@@ -92,8 +92,8 @@ struct MultisigArgOpt {
     execute_automatically: Option<bool>,
 }
 
-async fn submit_send(
-    client: ManyClient<impl Identity + 'static>,
+fn submit_send(
+    client: ManyClient,
     account: Address,
     multisig_arg: MultisigArgOpt,
     opts: TargetCommandOpt,
@@ -109,40 +109,42 @@ async fn submit_send(
         timeout,
         execute_automatically,
     } = multisig_arg;
-    let symbol = crate::resolve_symbol(&client, symbol).await?;
+    let symbol = crate::resolve_symbol(&client, symbol)?;
 
-    let transaction = events::AccountMultisigTransaction::Send(ledger::SendArgs {
-        from: from.or(Some(account)),
-        to: identity,
-        symbol,
-        amount: TokenAmount::from(amount),
-    });
-    let arguments = multisig::SubmitTransactionArgs {
-        account,
-        memo: None,
-        transaction: Box::new(transaction),
-        threshold,
-        timeout_in_secs: timeout.map(|d| d.as_secs()),
-        execute_automatically,
-        data: None,
-    };
-    let response = client
-        .call("account.multisigSubmitTransaction", arguments)
-        .await?;
+    if client.id.identity.is_anonymous() {
+        Err(ManyError::invalid_identity())
+    } else {
+        let transaction = events::AccountMultisigTransaction::Send(ledger::SendArgs {
+            from: from.or(Some(account)),
+            to: identity,
+            symbol,
+            amount: TokenAmount::from(amount),
+        });
+        let arguments = multisig::SubmitTransactionArgs {
+            account,
+            memo: None,
+            transaction: Box::new(transaction),
+            threshold,
+            timeout_in_secs: timeout.map(|d| d.as_secs()),
+            execute_automatically,
+            data: None,
+        };
+        let response = client.call("account.multisigSubmitTransaction", arguments)?;
 
-    let payload = crate::wait_response(client, response).await?;
-    let result: multisig::SubmitTransactionReturn =
-        minicbor::decode(&payload).map_err(|e| ManyError::deserialization_error(e.to_string()))?;
+        let payload = crate::wait_response(client, response)?;
+        let result: multisig::SubmitTransactionReturn = minicbor::decode(&payload)
+            .map_err(|e| ManyError::deserialization_error(e.to_string()))?;
 
-    info!(
-        "Transaction Token: {}",
-        hex::encode(result.token.as_slice())
-    );
-    Ok(())
+        info!(
+            "Transaction Token: {}",
+            hex::encode(result.token.as_slice())
+        );
+        Ok(())
+    }
 }
 
-async fn submit_set_defaults(
-    client: ManyClient<impl Identity + 'static>,
+fn submit_set_defaults(
+    client: ManyClient,
     account: Address,
     multisig_arg: MultisigArgOpt,
     target: Address,
@@ -154,155 +156,161 @@ async fn submit_set_defaults(
         execute_automatically,
     } = multisig_arg;
 
-    let transaction =
-        events::AccountMultisigTransaction::AccountMultisigSetDefaults(multisig::SetDefaultsArgs {
-            account: target,
-            threshold: opts.threshold,
-            timeout_in_secs: opts.timeout.map(|d| d.as_secs()),
-            execute_automatically: opts.execute_automatically,
-        });
-    let arguments = multisig::SubmitTransactionArgs {
-        account,
-        memo: None,
-        transaction: Box::new(transaction),
-        threshold,
-        timeout_in_secs: timeout.map(|d| d.as_secs()),
-        execute_automatically,
-        data: None,
-    };
-    let response = client
-        .call("account.multisigSubmitTransaction", arguments)
-        .await?;
+    if client.id.identity.is_anonymous() {
+        Err(ManyError::invalid_identity())
+    } else {
+        let transaction = events::AccountMultisigTransaction::AccountMultisigSetDefaults(
+            multisig::SetDefaultsArgs {
+                account: target,
+                threshold: opts.threshold,
+                timeout_in_secs: opts.timeout.map(|d| d.as_secs()),
+                execute_automatically: opts.execute_automatically,
+            },
+        );
+        let arguments = multisig::SubmitTransactionArgs {
+            account,
+            memo: None,
+            transaction: Box::new(transaction),
+            threshold,
+            timeout_in_secs: timeout.map(|d| d.as_secs()),
+            execute_automatically,
+            data: None,
+        };
+        let response = client.call("account.multisigSubmitTransaction", arguments)?;
 
-    let payload = crate::wait_response(client, response).await?;
-    let result: multisig::SubmitTransactionReturn =
-        minicbor::decode(&payload).map_err(|e| ManyError::deserialization_error(e.to_string()))?;
+        let payload = crate::wait_response(client, response)?;
+        let result: multisig::SubmitTransactionReturn = minicbor::decode(&payload)
+            .map_err(|e| ManyError::deserialization_error(e.to_string()))?;
 
-    info!(
-        "Transaction Token: {}",
-        hex::encode(result.token.as_slice())
-    );
-    Ok(())
+        info!(
+            "Transaction Token: {}",
+            hex::encode(result.token.as_slice())
+        );
+        Ok(())
+    }
 }
 
-async fn submit(
-    client: ManyClient<impl Identity + 'static>,
+fn submit(
+    client: ManyClient,
     account: Address,
     multisig_arg: MultisigArgOpt,
     opts: SubmitOpt,
 ) -> Result<(), ManyError> {
     match opts {
-        SubmitOpt::Send(target) => submit_send(client, account, multisig_arg, target).await,
+        SubmitOpt::Send(target) => submit_send(client, account, multisig_arg, target),
         SubmitOpt::SetDefaults(SetDefaultsOpt {
             target_account,
             opts,
-        }) => submit_set_defaults(client, account, multisig_arg, target_account, opts).await,
+        }) => submit_set_defaults(client, account, multisig_arg, target_account, opts),
     }
 }
 
-async fn approve(
-    client: ManyClient<impl Identity + 'static>,
-    opts: TransactionOpt,
-) -> Result<(), ManyError> {
-    let arguments = multisig::ApproveArgs { token: opts.token };
-    let response = client.call("account.multisigApprove", arguments).await?;
+fn approve(client: ManyClient, opts: TransactionOpt) -> Result<(), ManyError> {
+    if client.id.identity.is_anonymous() {
+        Err(ManyError::invalid_identity())
+    } else {
+        let arguments = multisig::ApproveArgs { token: opts.token };
+        let response = client.call("account.multisigApprove", arguments)?;
 
-    let payload = crate::wait_response(client, response).await?;
-    let _result: multisig::ApproveReturn =
-        minicbor::decode(&payload).map_err(|e| ManyError::deserialization_error(e.to_string()))?;
+        let payload = crate::wait_response(client, response)?;
+        let _result: multisig::ApproveReturn = minicbor::decode(&payload)
+            .map_err(|e| ManyError::deserialization_error(e.to_string()))?;
 
-    info!("Approved.");
+        info!("Approved.");
 
-    Ok(())
+        Ok(())
+    }
 }
 
-async fn revoke(
-    client: ManyClient<impl Identity + 'static>,
-    opts: TransactionOpt,
-) -> Result<(), ManyError> {
-    let arguments = multisig::RevokeArgs { token: opts.token };
-    let response = client.call("account.multisigRevoke", arguments).await?;
+fn revoke(client: ManyClient, opts: TransactionOpt) -> Result<(), ManyError> {
+    if client.id.identity.is_anonymous() {
+        Err(ManyError::invalid_identity())
+    } else {
+        let arguments = multisig::RevokeArgs { token: opts.token };
+        let response = client.call("account.multisigRevoke", arguments)?;
 
-    let payload = crate::wait_response(client, response).await?;
-    let _result: multisig::RevokeReturn =
-        minicbor::decode(&payload).map_err(|e| ManyError::deserialization_error(e.to_string()))?;
+        let payload = crate::wait_response(client, response)?;
+        let _result: multisig::RevokeReturn = minicbor::decode(&payload)
+            .map_err(|e| ManyError::deserialization_error(e.to_string()))?;
 
-    info!("Revoked.");
+        info!("Revoked.");
 
-    Ok(())
+        Ok(())
+    }
 }
 
-async fn execute(
-    client: ManyClient<impl Identity + 'static>,
-    opts: TransactionOpt,
-) -> Result<(), ManyError> {
-    let arguments = multisig::ExecuteArgs { token: opts.token };
-    let response = client.call("account.multisigExecute", arguments).await?;
+fn execute(client: ManyClient, opts: TransactionOpt) -> Result<(), ManyError> {
+    if client.id.identity.is_anonymous() {
+        Err(ManyError::invalid_identity())
+    } else {
+        let arguments = multisig::ExecuteArgs { token: opts.token };
+        let response = client.call("account.multisigExecute", arguments)?;
 
-    let payload = crate::wait_response(client, response).await?;
-    let result: ResponseMessage =
-        minicbor::decode(&payload).map_err(|e| ManyError::deserialization_error(e.to_string()))?;
+        let payload = crate::wait_response(client, response)?;
+        let result: ResponseMessage = minicbor::decode(&payload)
+            .map_err(|e| ManyError::deserialization_error(e.to_string()))?;
 
-    info!("Executed:");
-    println!("{}", minicbor::display(&result.data?));
-    Ok(())
+        info!("Executed:");
+        println!("{}", minicbor::display(&result.data?));
+        Ok(())
+    }
 }
 
-async fn info(
-    client: ManyClient<impl Identity + 'static>,
-    opts: TransactionOpt,
-) -> Result<(), ManyError> {
-    let arguments = multisig::InfoArgs { token: opts.token };
-    let response = client.call("account.multisigInfo", arguments).await?;
+fn info(client: ManyClient, opts: TransactionOpt) -> Result<(), ManyError> {
+    if client.id.identity.is_anonymous() {
+        Err(ManyError::invalid_identity())
+    } else {
+        let arguments = multisig::InfoArgs { token: opts.token };
+        let response = client.call("account.multisigInfo", arguments)?;
 
-    let payload = crate::wait_response(client, response).await?;
-    let result: multisig::InfoReturn =
-        minicbor::decode(&payload).map_err(|e| ManyError::deserialization_error(e.to_string()))?;
+        let payload = crate::wait_response(client, response)?;
+        let result: multisig::InfoReturn = minicbor::decode(&payload)
+            .map_err(|e| ManyError::deserialization_error(e.to_string()))?;
 
-    println!("{:#?}", result);
-    Ok(())
+        println!("{:#?}", result);
+        Ok(())
+    }
 }
 
-async fn set_defaults(
-    client: ManyClient<impl Identity + 'static>,
+fn set_defaults(
+    client: ManyClient,
     account: Address,
     opts: MultisigArgOpt,
 ) -> Result<(), ManyError> {
-    let arguments = multisig::SetDefaultsArgs {
-        account,
-        threshold: opts.threshold,
-        timeout_in_secs: opts.timeout.map(|d| d.as_secs()),
-        execute_automatically: opts.execute_automatically,
-    };
-    let response = client
-        .call("account.multisigSetDefaults", arguments)
-        .await?;
+    if client.id.identity.is_anonymous() {
+        Err(ManyError::invalid_identity())
+    } else {
+        let arguments = multisig::SetDefaultsArgs {
+            account,
+            threshold: opts.threshold,
+            timeout_in_secs: opts.timeout.map(|d| d.as_secs()),
+            execute_automatically: opts.execute_automatically,
+        };
+        let response = client.call("account.multisigSetDefaults", arguments)?;
 
-    let payload = crate::wait_response(client, response).await?;
-    let _result: multisig::SetDefaultsReturn =
-        minicbor::decode(&payload).map_err(|e| ManyError::deserialization_error(e.to_string()))?;
+        let payload = crate::wait_response(client, response)?;
+        let _result: multisig::SetDefaultsReturn = minicbor::decode(&payload)
+            .map_err(|e| ManyError::deserialization_error(e.to_string()))?;
 
-    info!("Defaults set.");
-    Ok(())
+        info!("Defaults set.");
+        Ok(())
+    }
 }
 
-pub async fn multisig(
-    client: ManyClient<impl Identity + 'static>,
-    opts: CommandOpt,
-) -> Result<(), ManyError> {
+pub fn multisig(client: ManyClient, opts: CommandOpt) -> Result<(), ManyError> {
     match opts.subcommand {
         SubcommandOpt::Submit {
             account,
             multisig_arg,
             subcommand,
-        } => submit(client, account, multisig_arg, subcommand).await,
-        SubcommandOpt::Approve(sub_opts) => approve(client, sub_opts).await,
-        SubcommandOpt::Revoke(sub_opts) => revoke(client, sub_opts).await,
-        SubcommandOpt::Execute(sub_opts) => execute(client, sub_opts).await,
-        SubcommandOpt::Info(sub_opts) => info(client, sub_opts).await,
+        } => submit(client, account, multisig_arg, subcommand),
+        SubcommandOpt::Approve(sub_opts) => approve(client, sub_opts),
+        SubcommandOpt::Revoke(sub_opts) => revoke(client, sub_opts),
+        SubcommandOpt::Execute(sub_opts) => execute(client, sub_opts),
+        SubcommandOpt::Info(sub_opts) => info(client, sub_opts),
         SubcommandOpt::SetDefaults(SetDefaultsOpt {
             target_account,
             opts,
-        }) => set_defaults(client, target_account, opts).await,
+        }) => set_defaults(client, target_account, opts),
     }
 }

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -23,15 +23,13 @@ coset = "0.3"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["ed25519", "ecdsa"] }
-many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
 reqwest = "0.11.11"
 sha2 = "0.10.1"
 signal-hook = "0.3.13"

--- a/src/many-abci/src/abci_app.rs
+++ b/src/many-abci/src/abci_app.rs
@@ -1,7 +1,7 @@
 use coset::{CborSerializable, CoseSign1};
 use many_client::ManyClient;
 use many_error::ManyError;
-use many_identity::{Address, AnonymousIdentity};
+use many_identity::{Address, CoseKeyIdentity};
 use many_modules::abci_backend::{AbciBlock, AbciCommitInfo, AbciInfo};
 use many_protocol::ResponseMessage;
 use reqwest::{IntoUrl, Url};
@@ -16,13 +16,13 @@ lazy_static::lazy_static!(
 #[derive(Debug, Clone)]
 pub struct AbciApp {
     app_name: String,
-    many_client: ManyClient<AnonymousIdentity>,
+    many_client: ManyClient,
     many_url: Url,
 }
 
 impl AbciApp {
     /// Constructor.
-    pub async fn create<U>(many_url: U, server_id: Address) -> Result<Self, String>
+    pub fn create<U>(many_url: U, server_id: Address) -> Result<Self, String>
     where
         U: IntoUrl,
     {
@@ -35,8 +35,9 @@ impl AbciApp {
         //     server_id
         // };
 
-        let many_client = ManyClient::new(many_url.clone(), server_id, AnonymousIdentity)?;
-        let status = many_client.status().await.map_err(|x| x.to_string())?;
+        let many_client =
+            ManyClient::new(many_url.clone(), server_id, CoseKeyIdentity::anonymous())?;
+        let status = many_client.status().map_err(|x| x.to_string())?;
         let app_name = status.name;
 
         Ok(Self {
@@ -55,7 +56,7 @@ impl Application for AbciApp {
         );
 
         let AbciInfo { height, hash } =
-            match smol::block_on(self.many_client.call_("abci.info", ())).and_then(|payload| {
+            match self.many_client.call_("abci.info", ()).and_then(|payload| {
                 minicbor::decode(&payload)
                     .map_err(|e| ManyError::deserialization_error(e.to_string()))
             }) {
@@ -90,10 +91,7 @@ impl Application for AbciApp {
                 }
             }
         };
-        let value = match smol::block_on(many_client::client::send_envelope(
-            self.many_url.clone(),
-            cose,
-        )) {
+        let value = match ManyClient::send_envelope(self.many_url.clone(), cose) {
             Ok(cose_sign) => cose_sign,
 
             Err(err) => {
@@ -140,10 +138,7 @@ impl Application for AbciApp {
                 }
             }
         };
-        match smol::block_on(many_client::client::send_envelope(
-            self.many_url.clone(),
-            cose,
-        )) {
+        match ManyClient::send_envelope(self.many_url.clone(), cose) {
             Ok(cose_sign) => {
                 let payload = cose_sign.payload.unwrap_or_default();
                 let mut response = ResponseMessage::from_bytes(&payload).unwrap_or_default();
@@ -187,7 +182,7 @@ impl Application for AbciApp {
     }
 
     fn commit(&self) -> ResponseCommit {
-        smol::block_on(self.many_client.call_("abci.commit", ())).map_or_else(
+        self.many_client.call_("abci.commit", ()).map_or_else(
             |err| ResponseCommit {
                 data: err.to_string().into_bytes().into(),
                 retain_height: 0,

--- a/src/many-abci/src/many_app.rs
+++ b/src/many-abci/src/many_app.rs
@@ -1,9 +1,7 @@
 use async_trait::async_trait;
 use coset::{CborSerializable, CoseSign1};
 use many_error::ManyError;
-use many_identity::verifiers::AnonymousVerifier;
-use many_identity::Identity;
-use many_identity_dsa::{CoseKeyIdentity, CoseKeyVerifier};
+use many_identity::CoseKeyIdentity;
 use many_modules::abci_backend::{AbciInit, EndpointInfo, ABCI_MODULE_ATTRIBUTE};
 use many_modules::base;
 use many_protocol::{
@@ -29,7 +27,7 @@ pub struct AbciModuleMany<C: Client> {
 impl<C: Client + Sync> AbciModuleMany<C> {
     pub async fn new(client: C, backend_status: base::Status, identity: CoseKeyIdentity) -> Self {
         let init_message = RequestMessageBuilder::default()
-            .from(identity.address())
+            .from(identity.identity)
             .method("abci.init".to_string())
             .build()
             .unwrap();
@@ -40,9 +38,7 @@ impl<C: Client + Sync> AbciModuleMany<C> {
 
         let response = client.abci_query(None, data, None, false).await.unwrap();
         let response = CoseSign1::from_slice(&response.value).unwrap();
-        let response =
-            decode_response_from_cose_sign1(&response, None, &(AnonymousVerifier, CoseKeyVerifier))
-                .unwrap();
+        let response = decode_response_from_cose_sign1(response, None).unwrap();
         let init_message: AbciInit = minicbor::decode(&response.data.unwrap()).unwrap();
 
         Self {
@@ -54,8 +50,7 @@ impl<C: Client + Sync> AbciModuleMany<C> {
     }
 
     async fn execute_message(&self, envelope: CoseSign1) -> Result<CoseSign1, ManyError> {
-        let message =
-            decode_request_from_cose_sign1(&envelope, &(AnonymousVerifier, CoseKeyVerifier))?;
+        let message = decode_request_from_cose_sign1(envelope.clone(), None)?;
         if let Some(info) = self.backend_endpoints.get(&message.method) {
             let is_command = info.is_command;
             let data = envelope
@@ -71,7 +66,7 @@ impl<C: Client + Sync> AbciModuleMany<C> {
 
                 // A command will always return an empty payload with an ASYNC attribute.
                 let response =
-                    ResponseMessage::from_request(&message, &self.identity.address(), Ok(vec![]))
+                    ResponseMessage::from_request(&message, &self.identity.identity, Ok(vec![]))
                         .with_attribute(
                             many_modules::r#async::attributes::ASYNC
                                 .with_argument(CborAny::Bytes(response.hash.as_bytes().to_vec())),
@@ -108,8 +103,8 @@ impl<C: Client + Sync + Send> LowLevelManyRequestHandler for AbciModuleMany<C> {
         match result {
             Ok(x) => Ok(x),
             Err(e) => {
-                let response = ResponseMessage::error(self.identity.address(), None, e);
-                encode_cose_sign1_from_response(response, &self.identity).map_err(|e| e.to_string())
+                let response = ResponseMessage::error(&self.identity.identity, None, e);
+                encode_cose_sign1_from_response(response, &self.identity)
             }
         }
     }
@@ -136,7 +131,7 @@ impl<C: Client + Sync + Send> base::BaseModuleBackend for AbciModuleMany<C> {
         builder
             .name(format!("AbciModule({})", self.backend_status.name))
             .version(1)
-            .identity(self.identity.address())
+            .identity(self.identity.identity)
             .attributes(attributes.into_iter().collect())
             .server_version(std::env!("CARGO_PKG_VERSION").to_string());
 

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -25,12 +25,11 @@ lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
 many-abci = { path = "../many-abci" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["default", "serde"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["ed25519", "ecdsa"] }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1", features = ["default", "serde"] }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
 serde = "1.0.130"
 serde_json = "1.0.72"
 sha3 = "0.9.1"
@@ -40,5 +39,5 @@ tracing-subscriber = "0.3"
 tracing-syslog = { git = "https://github.com/max-heller/tracing-syslog.git", rev = "6ff222831d7a78f1068d4c8af94dea215b07f114" }
 
 [dev-dependencies]
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["testing"] }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1", features = ["default", "serde", "testing"] }
 tempfile = "3.3.0"

--- a/src/many-kvstore/src/main.rs
+++ b/src/many-kvstore/src/main.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
-use many_identity::verifiers::AnonymousVerifier;
-use many_identity_dsa::{CoseKeyIdentity, CoseKeyVerifier};
+use many_identity::CoseKeyIdentity;
 use many_modules::{abci_backend, kvstore};
 use many_server::transport::http::HttpServer;
 use many_server::ManyServer;
@@ -126,8 +125,8 @@ fn main() {
     let many = ManyServer::simple(
         "many-kvstore",
         key,
-        (AnonymousVerifier, CoseKeyVerifier),
-        Some(env!("CARGO_PKG_VERSION").to_string()),
+        Some(std::env!("CARGO_PKG_VERSION").to_string()),
+        None,
     );
 
     {

--- a/src/many-kvstore/tests/common/mod.rs
+++ b/src/many-kvstore/tests/common/mod.rs
@@ -1,5 +1,5 @@
-use many_identity::{Address, Identity};
-use many_identity_dsa::ed25519::generate_random_ed25519_identity;
+use many_identity::testsutils::generate_random_eddsa_identity;
+use many_identity::Address;
 use many_kvstore::module::KvStoreModuleImpl;
 
 pub struct Setup {
@@ -15,13 +15,13 @@ impl Default for Setup {
 
 impl Setup {
     pub fn new(blockchain: bool) -> Self {
-        let id = generate_random_ed25519_identity();
+        let id = generate_random_eddsa_identity();
         let content = std::fs::read_to_string("../../staging/kvstore_state.json").unwrap();
         let state = serde_json::from_str(&content).unwrap();
         Self {
             module_impl: KvStoreModuleImpl::new(state, tempfile::tempdir().unwrap(), blockchain)
                 .unwrap(),
-            id: id.address(),
+            id: id.identity,
         }
     }
 }

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -32,14 +32,12 @@ num-bigint = "0.4.3"
 num-traits = "0.2.14"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
 many-abci = { path = "../many-abci" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["default", "serde"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["ed25519", "ecdsa"] }
-many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1", features = ["default", "serde"] }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
 rand = "0.8"
 serde = "1.0.130"
 serde_json = "1.0.72"
@@ -54,9 +52,8 @@ typenum = "1.15.0"
 
 [dev-dependencies]
 once_cell = "1.12"
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["default", "serde", "testing"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "647b729969d358198e80464b95a42ee58a203891", features = ["ed25519", "testing"] }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "c8d0cf59eb68e4112dae71823b5e1ba0d2c25ab1", features = ["default", "serde", "testing"] }
 many-ledger = { path = ".", features = ["balance_testing"]}
 proptest = "1"
 tempfile = "3.3.0"

--- a/src/many-ledger/src/main.rs
+++ b/src/many-ledger/src/main.rs
@@ -1,8 +1,5 @@
 use clap::Parser;
-use many_identity::verifiers::AnonymousVerifier;
-use many_identity::{Address, Identity};
-use many_identity_dsa::{CoseKeyIdentity, CoseKeyVerifier};
-use many_identity_webauthn::WebAuthnVerifier;
+use many_identity::{Address, CoseKeyIdentity};
 use many_modules::account::features::Feature;
 use many_modules::{abci_backend, account, events, idstore, ledger};
 use many_protocol::ManyUrl;
@@ -159,7 +156,7 @@ fn main() {
 
     let pem = std::fs::read_to_string(&pem).expect("Could not read PEM file.");
     let key = CoseKeyIdentity::from_pem(&pem).expect("Could not generate identity from PEM file.");
-    info!(address = key.address().to_string().as_str());
+    info!(address = key.identity.to_string().as_str());
 
     let state: Option<InitialStateJson> =
         state.map(|p| InitialStateJson::read(p).expect("Could not read state file."));
@@ -196,12 +193,8 @@ fn main() {
     let many = ManyServer::simple(
         "many-ledger",
         key,
-        (
-            AnonymousVerifier,
-            CoseKeyVerifier,
-            WebAuthnVerifier::new(allow_origin),
-        ),
         Some(env!("CARGO_PKG_VERSION").to_string()),
+        allow_origin,
     );
 
     {

--- a/src/many-ledger/src/module.rs
+++ b/src/many-ledger/src/module.rs
@@ -861,17 +861,16 @@ mod tests {
     use crate::json::InitialStateJson;
     use crate::module::LedgerModuleImpl;
     use coset::CborSerializable;
-    use many_identity::Identity;
-    use many_identity_dsa::ed25519::generate_random_ed25519_identity;
+    use many_identity::testsutils::generate_random_eddsa_identity;
     use many_modules::idstore;
     use many_modules::idstore::IdStoreModuleBackend;
 
     #[test]
     /// Test every recall phrase generation codepath
     fn idstore_generate_recall_phrase_all_codepaths() {
-        let cose_key_id = generate_random_ed25519_identity();
+        let cose_key_id = generate_random_eddsa_identity();
         let public_key: idstore::PublicKey =
-            idstore::PublicKey(cose_key_id.public_key().to_vec().unwrap().into());
+            idstore::PublicKey(cose_key_id.key.unwrap().to_vec().unwrap().into());
         let mut module_impl = LedgerModuleImpl::new(
             Some(
                 InitialStateJson::read("../../staging/ledger_state.json5")
@@ -882,7 +881,7 @@ mod tests {
         )
         .unwrap();
         let cred_id = idstore::CredentialId(vec![1; 16].into());
-        let id = cose_key_id.address();
+        let id = cose_key_id.identity;
 
         // Basic call
         let result = module_impl.store(

--- a/src/many-ledger/tests/common/mod.rs
+++ b/src/many-ledger/tests/common/mod.rs
@@ -1,8 +1,8 @@
 use coset::CborSerializable;
 use many_error::ManyError;
 use many_identity::testing::identity;
-use many_identity::{Address, Identity};
-use many_identity_dsa::ed25519::generate_random_ed25519_identity;
+use many_identity::testsutils::generate_random_eddsa_identity;
+use many_identity::Address;
 use many_ledger::json::InitialStateJson;
 use many_ledger::module::LedgerModuleImpl;
 use many_modules::abci_backend::{AbciBlock, ManyAbciModuleBackend};
@@ -86,8 +86,8 @@ impl Default for Setup {
 
 impl Setup {
     pub fn new(blockchain: bool) -> Self {
-        let id = generate_random_ed25519_identity();
-        let public_key = PublicKey(id.public_key().to_vec().unwrap().into());
+        let id = generate_random_eddsa_identity();
+        let public_key = PublicKey(id.clone().key.unwrap().to_vec().unwrap().into());
 
         Self {
             module_impl: LedgerModuleImpl::new(
@@ -99,7 +99,7 @@ impl Setup {
                 blockchain,
             )
             .unwrap(),
-            id: id.address(),
+            id: id.identity,
             cred_id: CredentialId(vec![1; 16].into()),
             public_key,
             time: Some(1_000_000),

--- a/src/many-ledger/tests/iterator.rs
+++ b/src/many-ledger/tests/iterator.rs
@@ -1,4 +1,3 @@
-use many_identity::testing::identity;
 use many_identity::Address;
 use many_ledger::storage::LedgerStorage;
 use many_modules::events::{EventId, EventLog};
@@ -9,16 +8,24 @@ use std::ops::Bound;
 
 fn setup() -> LedgerStorage {
     let symbol0 = Address::anonymous();
-    let id0 = identity(0);
-    let id1 = identity(1);
-    let id2 = identity(2);
+    let id0 = Address::public_key_raw([0; 28]);
+    let id1 = Address::public_key_raw([1; 28]);
+    let id2 = Address::public_key_raw([2; 28]);
 
     let symbols = BTreeMap::from_iter(vec![(symbol0, "MFX".to_string())].into_iter());
     let balances = BTreeMap::from([(id0, BTreeMap::from([(symbol0, TokenAmount::from(1000u16))]))]);
     let persistent_path = tempfile::tempdir().unwrap();
 
-    let mut storage =
-        LedgerStorage::new(symbols, balances, persistent_path, id2, false, None, None).unwrap();
+    let mut storage = many_ledger::storage::LedgerStorage::new(
+        symbols,
+        balances,
+        persistent_path,
+        id2,
+        false,
+        None,
+        None,
+    )
+    .unwrap();
 
     for _ in 0..5 {
         storage


### PR DESCRIPTION
Reverts liftedinit/many-framework#226

This PR was not ready to be merged.

- Resiliency test "Network is consistent with 1 node down" is consistently failing locally
- Resiliency test "Node can catch up" is consistently failing locally
- Need to replace `smol` with `tokio runtime` (#228)

More investigation and testing are required.