### PR TITLE
Improvements for the E2E Docker on MacOS

### DIFF
--- a/docker/e2e/Cargo.nix
+++ b/docker/e2e/Cargo.nix
@@ -905,11 +905,11 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".console."0.15.0" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".console."0.15.1" = overridableMkRustCrate (profileName: rec {
     name = "console";
-    version = "0.15.0";
+    version = "0.15.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"; };
+    src = fetchCratesIo { inherit name version; sha256 = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"; };
     dependencies = {
       ${ if hostPlatform.isWindows then "encode_unicode" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".encode_unicode."0.3.6" { inherit profileName; };
       libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.126" { inherit profileName; };
@@ -2401,7 +2401,7 @@ in
       [ "default" ]
     ];
     dependencies = {
-      console = rustPackages."registry+https://github.com/rust-lang/crates.io-index".console."0.15.0" { inherit profileName; };
+      console = rustPackages."registry+https://github.com/rust-lang/crates.io-index".console."0.15.1" { inherit profileName; };
       lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
       number_prefix = rustPackages."registry+https://github.com/rust-lang/crates.io-index".number_prefix."0.4.0" { inherit profileName; };
       regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.6.0" { inherit profileName; };

--- a/docker/e2e/Cargo.nix
+++ b/docker/e2e/Cargo.nix
@@ -905,11 +905,11 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".console."0.15.1" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".console."0.15.0" = overridableMkRustCrate (profileName: rec {
     name = "console";
-    version = "0.15.1";
+    version = "0.15.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"; };
+    src = fetchCratesIo { inherit name version; sha256 = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"; };
     dependencies = {
       ${ if hostPlatform.isWindows then "encode_unicode" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".encode_unicode."0.3.6" { inherit profileName; };
       libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.126" { inherit profileName; };
@@ -2401,7 +2401,7 @@ in
       [ "default" ]
     ];
     dependencies = {
-      console = rustPackages."registry+https://github.com/rust-lang/crates.io-index".console."0.15.1" { inherit profileName; };
+      console = rustPackages."registry+https://github.com/rust-lang/crates.io-index".console."0.15.0" { inherit profileName; };
       lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
       number_prefix = rustPackages."registry+https://github.com/rust-lang/crates.io-index".number_prefix."0.4.0" { inherit profileName; };
       regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.6.0" { inherit profileName; };

--- a/docker/e2e/Makefile
+++ b/docker/e2e/Makefile
@@ -28,7 +28,7 @@ lockfile:
 Cargo.nix: lockfile
 	docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v nix-store:/nix -v $(VOLUME):/volume -w /volume/many-framework nixos/nix bash docker/e2e/generate-cargo-nix.sh
 
-genfiles/many-ledger.tar.gz: $(shell find ../../src -type f) Cargo.nix flake.nix flake.lock
+genfiles/many-ledger.tar.gz: $(shell find ../../src -type f) flake.nix flake.lock
 	@mkdir -p genfiles
 	$(BUILDER_COMMAND) .#docker-many-ledger
 
@@ -36,7 +36,7 @@ genfiles/many-ledger.tar.gz: $(shell find ../../src -type f) Cargo.nix flake.nix
 many/many-ledger: genfiles/many-ledger.tar.gz
 	docker load < genfiles/many-ledger.tar.gz
 
-genfiles/many-abci.tar.gz: $(shell find ../../src -type f) Cargo.nix flake.nix flake.lock
+genfiles/many-abci.tar.gz: $(shell find ../../src -type f) flake.nix flake.lock
 	@mkdir -p genfiles
 	$(BUILDER_COMMAND) .#docker-many-abci
 

--- a/docker/e2e/Makefile
+++ b/docker/e2e/Makefile
@@ -19,9 +19,11 @@ clean:
 	fi
 	rm -rf genfiles
 
-../../Cargo.lock: $(shell find ../../ -name Cargo.toml)
+.PHONY: lockfile
+lockfile:
 	cd ../..; cargo fetch
-	touch $@
+
+../../Cargo.lock: lockfile
 
 Cargo.nix: ../../Cargo.lock
 	docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v nix-store:/nix -v $(VOLUME):/volume -w /volume/many-framework nixpkgs/nix-flakes bash docker/e2e/generate-cargo-nix.sh

--- a/docker/e2e/Makefile
+++ b/docker/e2e/Makefile
@@ -1,7 +1,7 @@
 # Options
 NB_NODES ?= 4
 ID_WITH_BALANCES ?=
-CPUCORES ?= $$(nproc)
+CPUCORES ?= $$(docker run --rm nixpkgs/nix-flakes nproc)
 TENDERMINT_VERSION ?= 0.35.4
 ABCI_TAG ?= "latest"
 LEDGER_TAG ?= "latest"

--- a/docker/e2e/Makefile
+++ b/docker/e2e/Makefile
@@ -1,7 +1,7 @@
 # Options
 NB_NODES ?= 4
 ID_WITH_BALANCES ?=
-CPUCORES ?= $$(docker run --rm nixpkgs/nix-flakes nproc)
+CPUCORES ?= $$(docker run --rm nixos/nix nproc)
 TENDERMINT_VERSION ?= 0.35.4
 ABCI_TAG ?= "latest"
 LEDGER_TAG ?= "latest"
@@ -9,7 +9,7 @@ LEDGER_TAG ?= "latest"
 # Constants
 VOLUME = $(abspath $(dir $(abspath $(dir $(abspath $(dir $(abspath $(dir $$PWD))))))))
 UINFO = $$(id -u):$$(id -g)
-BUILDER_COMMAND = docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v $(VOLUME):/volume -v nix-store:/nix -w /volume/many-framework/docker/e2e/ nixpkgs/nix-flakes bash build-image.sh $@
+BUILDER_COMMAND = docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v $(VOLUME):/volume -v nix-store:/nix -w /volume/many-framework/docker/e2e/ nixos/nix bash build-image.sh $@
 SHELL = bash
 
 .PHONY: clean
@@ -26,7 +26,7 @@ lockfile:
 ../../Cargo.lock: lockfile
 
 Cargo.nix: lockfile
-	docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v nix-store:/nix -v $(VOLUME):/volume -w /volume/many-framework nixpkgs/nix-flakes bash docker/e2e/generate-cargo-nix.sh
+	docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v nix-store:/nix -v $(VOLUME):/volume -w /volume/many-framework nixos/nix bash docker/e2e/generate-cargo-nix.sh
 
 genfiles/many-ledger.tar.gz: $(shell find ../../src -type f) Cargo.nix flake.nix flake.lock
 	@mkdir -p genfiles

--- a/docker/e2e/Makefile
+++ b/docker/e2e/Makefile
@@ -25,7 +25,7 @@ lockfile:
 
 ../../Cargo.lock: lockfile
 
-Cargo.nix: ../../Cargo.lock
+Cargo.nix: lockfile
 	docker run --rm -e CPUCORES=$(CPUCORES) -e UINFO=$(UINFO) -v nix-store:/nix -v $(VOLUME):/volume -w /volume/many-framework nixpkgs/nix-flakes bash docker/e2e/generate-cargo-nix.sh
 
 genfiles/many-ledger.tar.gz: $(shell find ../../src -type f) Cargo.nix flake.nix flake.lock

--- a/docker/e2e/build-image.sh
+++ b/docker/e2e/build-image.sh
@@ -1,6 +1,7 @@
 set -bepu
 
 echo "filter-syscalls = false" >> /etc/nix/nix.conf
+echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
 nix build --max-jobs $CPUCORES $2
 cp $(readlink result) $1
 chown $UINFO $1

--- a/docker/e2e/build-image.sh
+++ b/docker/e2e/build-image.sh
@@ -1,5 +1,7 @@
-echo "filter-syscalls = false" >> /etc/nix/nix.conf &&
-    nix build --max-jobs $CPUCORES $2 &&
-    cp $(readlink result) $1 &&
-    chown $UINFO $1 &&
-    rm result
+set -bepu
+
+echo "filter-syscalls = false" >> /etc/nix/nix.conf
+nix build --max-jobs $CPUCORES $2
+cp $(readlink result) $1
+chown $UINFO $1
+rm result

--- a/docker/e2e/build-image.sh
+++ b/docker/e2e/build-image.sh
@@ -1,5 +1,5 @@
-echo "filter-syscalls = false" >> /etc/nix/nix.conf
-nix build --max-jobs $CPUCORES $2
-cp $(readlink result) $1
-chown $UINFO $1
-rm result
+echo "filter-syscalls = false" >> /etc/nix/nix.conf &&
+    nix build --max-jobs $CPUCORES $2 &&
+    cp $(readlink result) $1 &&
+    chown $UINFO $1 &&
+    rm result

--- a/docker/e2e/build-image.sh
+++ b/docker/e2e/build-image.sh
@@ -1,3 +1,4 @@
+echo "filter-syscalls = false" >> /etc/nix/nix.conf
 nix build --max-jobs $CPUCORES $2
 cp $(readlink result) $1
 chown $UINFO $1

--- a/docker/e2e/generate-cargo-nix.sh
+++ b/docker/e2e/generate-cargo-nix.sh
@@ -1,6 +1,7 @@
 set -bepu
 
 echo "filter-syscalls = false" >> /etc/nix/nix.conf
+echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
 nix run github:cargo2nix/cargo2nix --max-jobs $CPUCORES -- -f docker/e2e/Cargo.nix.new
 mv docker/e2e/Cargo.nix.new docker/e2e/Cargo.nix
 chown $UINFO docker/e2e/Cargo.nix

--- a/docker/e2e/generate-cargo-nix.sh
+++ b/docker/e2e/generate-cargo-nix.sh
@@ -1,4 +1,4 @@
-echo "filter-syscalls = false" >> /etc/nix/nix.conf
-nix run github:cargo2nix/cargo2nix --max-jobs $CPUCORES -- -f docker/e2e/Cargo.nix.new
-mv docker/e2e/Cargo.nix.new docker/e2e/Cargo.nix
-chown $UINFO docker/e2e/Cargo.nix
+echo "filter-syscalls = false" >> /etc/nix/nix.conf &&
+    nix run github:cargo2nix/cargo2nix --max-jobs $CPUCORES -- -f docker/e2e/Cargo.nix.new &&
+    mv docker/e2e/Cargo.nix.new docker/e2e/Cargo.nix &&
+    chown $UINFO docker/e2e/Cargo.nix

--- a/docker/e2e/generate-cargo-nix.sh
+++ b/docker/e2e/generate-cargo-nix.sh
@@ -1,4 +1,6 @@
-echo "filter-syscalls = false" >> /etc/nix/nix.conf &&
-    nix run github:cargo2nix/cargo2nix --max-jobs $CPUCORES -- -f docker/e2e/Cargo.nix.new &&
-    mv docker/e2e/Cargo.nix.new docker/e2e/Cargo.nix &&
-    chown $UINFO docker/e2e/Cargo.nix
+set -bepu
+
+echo "filter-syscalls = false" >> /etc/nix/nix.conf
+nix run github:cargo2nix/cargo2nix --max-jobs $CPUCORES -- -f docker/e2e/Cargo.nix.new
+mv docker/e2e/Cargo.nix.new docker/e2e/Cargo.nix
+chown $UINFO docker/e2e/Cargo.nix

--- a/docker/e2e/generate-cargo-nix.sh
+++ b/docker/e2e/generate-cargo-nix.sh
@@ -1,3 +1,4 @@
+echo "filter-syscalls = false" >> /etc/nix/nix.conf
 nix run github:cargo2nix/cargo2nix --max-jobs $CPUCORES -- -f docker/e2e/Cargo.nix.new
 mv docker/e2e/Cargo.nix.new docker/e2e/Cargo.nix
 chown $UINFO docker/e2e/Cargo.nix


### PR DESCRIPTION
## Description

Should change nix.conf to allow better builds on MacOS

## Related Issue

Fixes #237
Fixes #234

# Breaking changes

You need to run `docker volume rm nix-store` before using this newer version.

## Checklist:

- [X] I have read and followed the CONTRIBUTING guidelines for this project.
- [X] I have added or updated tests and they pass.
- [X] I have added or updated documentation and it is accurate.
- [X] I have noted any breaking changes in this module or downstream modules.
