### PR TITLE
Cargo resolver v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "src/http_proxy",

--- a/src/many-ledger/src/module.rs
+++ b/src/many-ledger/src/module.rs
@@ -2,8 +2,6 @@ use crate::json::InitialStateJson;
 use crate::migration::LedgerMigrations;
 use crate::{error, storage::LedgerStorage};
 use many_error::ManyError;
-use many_identity::Address;
-use many_types::ledger::Symbol;
 use std::fmt::Debug;
 use std::path::Path;
 use tracing::info;
@@ -99,7 +97,12 @@ impl LedgerModuleImpl {
     }
 
     #[cfg(feature = "balance_testing")]
-    pub fn set_balance_only_for_testing(&mut self, account: Address, balance: u64, symbol: Symbol) {
+    pub fn set_balance_only_for_testing(
+        &mut self,
+        account: many_identity::Address,
+        balance: u64,
+        symbol: many_types::ledger::Symbol,
+    ) {
         self.storage
             .set_balance_only_for_testing(account, balance, symbol);
     }

--- a/tests/e2e/ledger/allow_addrs.bats
+++ b/tests/e2e/ledger/allow_addrs.bats
@@ -13,7 +13,7 @@ function setup() {
     if ! [ $CI ]; then
         (
           cd "$GIT_ROOT"
-          cargo build
+          cargo build --all-features
         )
     fi
 


### PR DESCRIPTION
Use Cargo's resolver v2.

Fixes liftedinit/many-framework#280 

Note: Our Nix Docker setup will still rely on the old behavior since the `resolver=2` features are not well supported by `cargo2nix`. See https://github.com/cargo2nix/cargo2nix/issues/200

Relates liftedinit/many-rs#265