### PR TITLE
Bazel update

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -101,22 +101,22 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "event-listener",
  "futures-core",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
+ "async-lock",
  "async-task",
- "concurrent-queue",
+ "concurrent-queue 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fastrand",
  "futures-lite",
- "once_cell",
  "slab",
 ]
 
@@ -140,7 +140,7 @@ checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
  "async-lock",
  "autocfg",
- "concurrent-queue",
+ "concurrent-queue 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-lite",
  "libc",
  "log",
@@ -406,9 +406,9 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aec14f5d4e6e3f927cd0c81f72e5710d95ee9019fbeb4b3021193867491bfd8"
+checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
 
 [[package]]
 name = "byteorder"
@@ -444,9 +444,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 dependencies = [
  "jobserver",
 ]
@@ -474,9 +474,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -607,6 +607,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +688,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774646b687f63643eb0f4bf13dc263cb581c8c9e57973b6ddf78bda3994d88df"
 dependencies = [
  "debug-helper",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+dependencies = [
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -992,10 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "direct-cargo-bazel-deps"
-version = "0.0.1"
-
-[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
@@ -1179,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "fixed"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0371cd413fb63f8ec1b9eb4dff47fa2c88b21abc681771234c84808b9920991"
+checksum = "418922d2c280b8c68f82699494cc8c48f392233233a9a8b9a48a57a36c0ad0ef"
 dependencies = [
  "az",
  "bytemuck",
@@ -1590,9 +1604,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1745,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itertools"
@@ -1795,9 +1809,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kvstore"
@@ -1881,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi",
@@ -1913,6 +1930,26 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab56277eeaacac09e1398bcefc113319c6c8d4fb464f11c54ba247cdb65776e"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624b78e5a5f99b2c751812a14785a2c661f894a34bc3dd1f2ec3e3fffb4605e7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2041,20 +2078,13 @@ name = "many-identity"
 version = "0.1.0"
 source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
- "asn1 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base32",
  "coset",
  "crc-any",
- "cryptoki",
- "ed25519",
- "ed25519-dalek",
  "hex",
  "many-error",
  "minicbor",
  "once_cell",
- "p256",
- "pkcs8 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sha2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2179,13 +2209,14 @@ dependencies = [
  "hex",
  "itertools",
  "json5",
- "lazy_static",
+ "linkme",
  "many-client",
  "many-error",
  "many-identity",
  "many-identity-dsa",
  "many-identity-webauthn",
  "many-ledger",
+ "many-migration",
  "many-modules",
  "many-protocol",
  "many-server",
@@ -2227,6 +2258,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "many-migration"
+version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
+dependencies = [
+ "minicbor",
+ "serde",
+ "serde_json",
+ "strum",
+ "tracing",
+]
+
+[[package]]
 name = "many-modules"
 version = "0.1.0"
 source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
@@ -2262,13 +2305,12 @@ dependencies = [
  "num-bigint",
  "num-derive",
  "num-traits",
- "proptest",
- "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2406,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2504,20 +2546,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -2586,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
 name = "overload"
@@ -2719,9 +2752,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
+checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2729,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
+checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2739,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
+checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2752,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
+checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
 dependencies = [
  "once_cell",
  "pest",
@@ -2856,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
@@ -3058,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3069,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -3358,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6deb15c3a535e81438110111d90168d91721652f502abb147f31cde129f683d"
+checksum = "2794f0ba0179a8ca422c30d9975d86faf8306be0164bfc3b0b1ca4f060ac639d"
 dependencies = [
  "proc-macro2",
  "serde",
@@ -3583,6 +3616,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -3668,9 +3704,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
 name = "tempfile"
@@ -3859,13 +3895,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -3879,9 +3913,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,11 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "696b01deea96a5e549f1b5ae18589e1bbd5a1d71a36a243b5cf76a9433487cf2",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.11.0/rules_rust-v0.11.0.tar.gz",
-        "https://github.com/bazelbuild/rules_rust/releases/download/0.11.0/rules_rust-v0.11.0.tar.gz",
-    ],
+    sha256 = "324c2a86a8708d30475f324846b35965c432b63a35567ed2b5051b86791ce345",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.13.0/rules_rust-v0.13.0.tar.gz"],
 )
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
@@ -17,7 +14,7 @@ RUST_VERSION = "nightly"
 
 rust_register_toolchains(
     edition = "2021",
-    iso_date = "2022-08-23",
+    iso_date = "2022-11-13",
     version = RUST_VERSION,
 )
 

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "8a3345c946f5b06b6bed12bd5042eeb57f0c788cd4fdaaa5b2062c5a06e93884",
+  "checksum": "3486149e62f15a5fe08938e518678a9f5ffb552ff5bf4699cd0ebdd0189f28c4",
   "crates": {
     "aes 0.7.5": {
       "name": "aes",
@@ -356,7 +356,7 @@
         "deps": {
           "common": [
             {
-              "id": "chrono 0.4.22",
+              "id": "chrono 0.4.23",
               "target": "chrono"
             }
           ],
@@ -407,7 +407,7 @@
         "deps": {
           "common": [
             {
-              "id": "chrono 0.4.22",
+              "id": "chrono 0.4.23",
               "target": "chrono"
             }
           ],
@@ -449,7 +449,7 @@
         "deps": {
           "common": [
             {
-              "id": "chrono 0.4.22",
+              "id": "chrono 0.4.23",
               "target": "chrono"
             }
           ],
@@ -560,13 +560,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-executor 1.4.1": {
+    "async-executor 1.5.0": {
       "name": "async-executor",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-executor/1.4.1/download",
-          "sha256": "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+          "url": "https://crates.io/api/v1/crates/async-executor/1.5.0/download",
+          "sha256": "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
         }
       },
       "targets": [
@@ -591,11 +591,15 @@
         "deps": {
           "common": [
             {
+              "id": "async-lock 2.6.0",
+              "target": "async_lock"
+            },
+            {
               "id": "async-task 4.3.0",
               "target": "async_task"
             },
             {
-              "id": "concurrent-queue 1.2.4",
+              "id": "concurrent-queue 2.0.0",
               "target": "concurrent_queue"
             },
             {
@@ -607,10 +611,6 @@
               "target": "futures_lite"
             },
             {
-              "id": "once_cell 1.16.0",
-              "target": "once_cell"
-            },
-            {
               "id": "slab 0.4.7",
               "target": "slab"
             }
@@ -618,7 +618,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.4.1"
+        "version": "1.5.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -1571,7 +1571,7 @@
               "target": "clap"
             },
             {
-              "id": "env_logger 0.9.1",
+              "id": "env_logger 0.9.3",
               "target": "env_logger"
             },
             {
@@ -1599,7 +1599,7 @@
               "target": "quote"
             },
             {
-              "id": "regex 1.6.0",
+              "id": "regex 1.7.0",
               "target": "regex"
             },
             {
@@ -1721,7 +1721,7 @@
               "target": "quote"
             },
             {
-              "id": "regex 1.6.0",
+              "id": "regex 1.7.0",
               "target": "regex"
             },
             {
@@ -1996,7 +1996,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             }
           ],
@@ -2273,13 +2273,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "bytemuck 1.12.2": {
+    "bytemuck 1.12.3": {
       "name": "bytemuck",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytemuck/1.12.2/download",
-          "sha256": "5aec14f5d4e6e3f927cd0c81f72e5710d95ee9019fbeb4b3021193867491bfd8"
+          "url": "https://crates.io/api/v1/crates/bytemuck/1.12.3/download",
+          "sha256": "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
         }
       },
       "targets": [
@@ -2302,7 +2302,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.12.2"
+        "version": "1.12.3"
       },
       "license": "Zlib OR Apache-2.0 OR MIT"
     },
@@ -2457,7 +2457,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             },
             {
@@ -2504,13 +2504,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "cc 1.0.74": {
+    "cc 1.0.76": {
       "name": "cc",
-      "version": "1.0.74",
+      "version": "1.0.76",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cc/1.0.74/download",
-          "sha256": "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+          "url": "https://crates.io/api/v1/crates/cc/1.0.76/download",
+          "sha256": "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
         }
       },
       "targets": [
@@ -2558,7 +2558,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.74"
+        "version": "1.0.76"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2670,13 +2670,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "chrono 0.4.22": {
+    "chrono 0.4.23": {
       "name": "chrono",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/chrono/0.4.22/download",
-          "sha256": "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+          "url": "https://crates.io/api/v1/crates/chrono/0.4.23/download",
+          "sha256": "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
         }
       },
       "targets": [
@@ -2715,7 +2715,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.22"
+        "version": "0.4.23"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -3007,7 +3007,7 @@
               "target": "libc"
             },
             {
-              "id": "libloading 0.7.3",
+              "id": "libloading 0.7.4",
               "target": "libloading"
             }
           ],
@@ -3306,7 +3306,7 @@
         "deps": {
           "common": [
             {
-              "id": "os_str_bytes 6.3.1",
+              "id": "os_str_bytes 6.4.0",
               "target": "os_str_bytes"
             }
           ],
@@ -3409,6 +3409,52 @@
         },
         "edition": "2018",
         "version": "1.2.4"
+      },
+      "license": "Apache-2.0 OR MIT"
+    },
+    "concurrent-queue 2.0.0": {
+      "name": "concurrent-queue",
+      "version": "2.0.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/concurrent-queue/2.0.0/download",
+          "sha256": "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "concurrent_queue",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "concurrent_queue",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "crossbeam-utils 0.8.12",
+              "target": "crossbeam_utils"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "2.0.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -3826,6 +3872,69 @@
       },
       "license": "MIT"
     },
+    "crossbeam-utils 0.8.12": {
+      "name": "crossbeam-utils",
+      "version": "0.8.12",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.12/download",
+          "sha256": "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crossbeam_utils",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "crossbeam_utils",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "crossbeam-utils 0.8.12",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.8.12"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "crunchy 0.2.2": {
       "name": "crunchy",
       "version": "0.2.2",
@@ -4129,7 +4238,7 @@
               "target": "cryptoki_sys"
             },
             {
-              "id": "libloading 0.7.3",
+              "id": "libloading 0.7.4",
               "target": "libloading"
             },
             {
@@ -4204,7 +4313,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "libloading 0.7.3",
+              "id": "libloading 0.7.4",
               "target": "libloading"
             }
           ],
@@ -4224,7 +4333,7 @@
               "target": "bindgen"
             },
             {
-              "id": "target-lexicon 0.12.4",
+              "id": "target-lexicon 0.12.5",
               "target": "target_lexicon"
             }
           ],
@@ -5423,34 +5532,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "direct-cargo-bazel-deps 0.0.1": {
-      "name": "direct-cargo-bazel-deps",
-      "version": "0.0.1",
-      "repository": null,
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "direct_cargo_bazel_deps",
-            "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "direct_cargo_bazel_deps",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.0.1"
-      },
-      "license": null
-    },
     "ecdsa 0.12.4": {
       "name": "ecdsa",
       "version": "0.12.4",
@@ -6110,13 +6191,13 @@
       },
       "license": "0BSD"
     },
-    "env_logger 0.9.1": {
+    "env_logger 0.9.3": {
       "name": "env_logger",
-      "version": "0.9.1",
+      "version": "0.9.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/env_logger/0.9.1/download",
-          "sha256": "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+          "url": "https://crates.io/api/v1/crates/env_logger/0.9.3/download",
+          "sha256": "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
         }
       },
       "targets": [
@@ -6160,7 +6241,7 @@
               "target": "log"
             },
             {
-              "id": "regex 1.6.0",
+              "id": "regex 1.7.0",
               "target": "regex"
             },
             {
@@ -6171,7 +6252,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.9.1"
+        "version": "0.9.3"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6436,13 +6517,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "fixed 1.19.0": {
+    "fixed 1.20.0": {
       "name": "fixed",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fixed/1.19.0/download",
-          "sha256": "e0371cd413fb63f8ec1b9eb4dff47fa2c88b21abc681771234c84808b9920991"
+          "url": "https://crates.io/api/v1/crates/fixed/1.20.0/download",
+          "sha256": "418922d2c280b8c68f82699494cc8c48f392233233a9a8b9a48a57a36c0ad0ef"
         }
       },
       "targets": [
@@ -6484,11 +6565,11 @@
               "alias": "az_crate"
             },
             {
-              "id": "bytemuck 1.12.2",
+              "id": "bytemuck 1.12.3",
               "target": "bytemuck"
             },
             {
-              "id": "fixed 1.19.0",
+              "id": "fixed 1.20.0",
               "target": "build_script_build"
             },
             {
@@ -6503,7 +6584,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.19.0"
+        "version": "1.20.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8679,13 +8760,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "hyper 0.14.20": {
+    "hyper 0.14.23": {
       "name": "hyper",
-      "version": "0.14.20",
+      "version": "0.14.23",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hyper/0.14.20/download",
-          "sha256": "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+          "url": "https://crates.io/api/v1/crates/hyper/0.14.23/download",
+          "sha256": "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
         }
       },
       "targets": [
@@ -8787,7 +8868,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.14.20"
+        "version": "0.14.23"
       },
       "license": "MIT"
     },
@@ -8846,7 +8927,7 @@
               "target": "http"
             },
             {
-              "id": "hyper 0.14.20",
+              "id": "hyper 0.14.23",
               "target": "hyper"
             },
             {
@@ -8928,7 +9009,7 @@
               "target": "futures_util"
             },
             {
-              "id": "hyper 0.14.20",
+              "id": "hyper 0.14.23",
               "target": "hyper"
             },
             {
@@ -9002,11 +9083,11 @@
               "target": "bytes"
             },
             {
-              "id": "hyper 0.14.20",
+              "id": "hyper 0.14.23",
               "target": "hyper"
             },
             {
-              "id": "native-tls 0.2.10",
+              "id": "native-tls 0.2.11",
               "target": "native_tls"
             },
             {
@@ -9323,7 +9404,7 @@
               "target": "number_prefix"
             },
             {
-              "id": "regex 1.6.0",
+              "id": "regex 1.7.0",
               "target": "regex"
             }
           ],
@@ -9455,13 +9536,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ipnet 2.5.0": {
+    "ipnet 2.5.1": {
       "name": "ipnet",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ipnet/2.5.0/download",
-          "sha256": "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+          "url": "https://crates.io/api/v1/crates/ipnet/2.5.1/download",
+          "sha256": "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
         }
       },
       "targets": [
@@ -9487,7 +9568,7 @@
           "default"
         ],
         "edition": "2018",
-        "version": "2.5.0"
+        "version": "2.5.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -9688,7 +9769,7 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.4.0",
+              "id": "pest 2.4.1",
               "target": "pest"
             },
             {
@@ -9702,7 +9783,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "pest_derive 2.4.0",
+              "id": "pest_derive 2.4.1",
               "target": "pest_derive"
             }
           ],
@@ -9712,13 +9793,13 @@
       },
       "license": "ISC"
     },
-    "keccak 0.1.2": {
+    "keccak 0.1.3": {
       "name": "keccak",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/keccak/0.1.2/download",
-          "sha256": "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+          "url": "https://crates.io/api/v1/crates/keccak/0.1.3/download",
+          "sha256": "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
         }
       },
       "targets": [
@@ -9740,8 +9821,19 @@
         "compile_data_glob": [
           "**"
         ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(target_arch = \"aarch64\")": [
+              {
+                "id": "cpufeatures 0.2.5",
+                "target": "cpufeatures"
+              }
+            ]
+          }
+        },
         "edition": "2015",
-        "version": "0.1.2"
+        "version": "0.1.3"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -9994,7 +10086,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "regex 1.6.0",
+              "id": "regex 1.7.0",
               "target": "regex"
             },
             {
@@ -10159,7 +10251,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             },
             {
@@ -10173,13 +10265,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "libloading 0.7.3": {
+    "libloading 0.7.4": {
       "name": "libloading",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libloading/0.7.3/download",
-          "sha256": "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+          "url": "https://crates.io/api/v1/crates/libloading/0.7.4/download",
+          "sha256": "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
         }
       },
       "targets": [
@@ -10219,7 +10311,7 @@
           }
         },
         "edition": "2015",
-        "version": "0.7.3"
+        "version": "0.7.4"
       },
       "license": "ISC"
     },
@@ -10302,7 +10394,7 @@
               "target": "bindgen"
             },
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             },
             {
@@ -10392,7 +10484,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             },
             {
@@ -10410,6 +10502,104 @@
           }
         },
         "links": "z"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "linkme 0.3.5": {
+      "name": "linkme",
+      "version": "0.3.5",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/linkme/0.3.5/download",
+          "sha256": "cab56277eeaacac09e1398bcefc113319c6c8d4fb464f11c54ba247cdb65776e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "linkme",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "linkme",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "used_linker"
+        ],
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "linkme-impl 0.3.5",
+              "target": "linkme_impl"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.3.5"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "linkme-impl 0.3.5": {
+      "name": "linkme-impl",
+      "version": "0.3.5",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/linkme-impl/0.3.5/download",
+          "sha256": "624b78e5a5f99b2c751812a14785a2c661f894a34bc3dd1f2ec3e3fffb4605e7"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "linkme_impl",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "linkme_impl",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "used_linker"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.103",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.3.5"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -10828,7 +11018,7 @@
               "target": "ed25519_dalek"
             },
             {
-              "id": "fixed 1.19.0",
+              "id": "fixed 1.20.0",
               "target": "fixed"
             },
             {
@@ -10888,7 +11078,7 @@
               "target": "rand"
             },
             {
-              "id": "regex 1.6.0",
+              "id": "regex 1.7.0",
               "target": "regex"
             },
             {
@@ -11047,7 +11237,7 @@
               "target": "num_traits"
             },
             {
-              "id": "regex 1.6.0",
+              "id": "regex 1.7.0",
               "target": "regex"
             }
           ],
@@ -11109,10 +11299,6 @@
         "deps": {
           "common": [
             {
-              "id": "asn1 0.11.0",
-              "target": "asn1"
-            },
-            {
               "id": "base32 0.4.0",
               "target": "base32"
             },
@@ -11123,18 +11309,6 @@
             {
               "id": "crc-any 2.4.3",
               "target": "crc_any"
-            },
-            {
-              "id": "cryptoki 0.3.0",
-              "target": "cryptoki"
-            },
-            {
-              "id": "ed25519 1.5.2",
-              "target": "ed25519"
-            },
-            {
-              "id": "ed25519-dalek 1.0.1",
-              "target": "ed25519_dalek"
             },
             {
               "id": "hex 0.4.3",
@@ -11151,18 +11325,6 @@
             {
               "id": "once_cell 1.16.0",
               "target": "once_cell"
-            },
-            {
-              "id": "p256 0.9.0",
-              "target": "p256"
-            },
-            {
-              "id": "pkcs8 0.8.0",
-              "target": "pkcs8"
-            },
-            {
-              "id": "rand 0.7.3",
-              "target": "rand"
             },
             {
               "id": "serde 1.0.147",
@@ -11761,7 +11923,8 @@
           "**"
         ],
         "crate_features": [
-          "balance_testing"
+          "balance_testing",
+          "migration_testing"
         ],
         "deps": {
           "common": [
@@ -11782,7 +11945,7 @@
               "target": "coset"
             },
             {
-              "id": "fixed 1.19.0",
+              "id": "fixed 1.20.0",
               "target": "fixed"
             },
             {
@@ -11798,8 +11961,8 @@
               "target": "json5"
             },
             {
-              "id": "lazy_static 1.4.0",
-              "target": "lazy_static"
+              "id": "linkme 0.3.5",
+              "target": "linkme"
             },
             {
               "id": "many-error 0.1.0",
@@ -11820,6 +11983,10 @@
             {
               "id": "many-ledger 0.1.0",
               "target": "build_script_build"
+            },
+            {
+              "id": "many-migration 0.1.0",
+              "target": "many_migration"
             },
             {
               "id": "many-modules 0.1.0",
@@ -12007,12 +12174,73 @@
               "target": "serde"
             },
             {
-              "id": "serde_tokenstream 0.1.3",
+              "id": "serde_tokenstream 0.1.5",
               "target": "serde_tokenstream"
             },
             {
               "id": "syn 1.0.103",
               "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": null
+    },
+    "many-migration 0.1.0": {
+      "name": "many-migration",
+      "version": "0.1.0",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "207ca9fdd0e403b758a3a31752ab98daac14e980"
+          },
+          "strip_prefix": "src/many-migration"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "many_migration",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "many_migration",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "minicbor 0.18.0",
+              "target": "minicbor"
+            },
+            {
+              "id": "serde 1.0.147",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.87",
+              "target": "serde_json"
+            },
+            {
+              "id": "strum 0.24.1",
+              "target": "strum"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
             }
           ],
           "selects": {}
@@ -12194,14 +12422,6 @@
               "target": "num_traits"
             },
             {
-              "id": "proptest 1.0.0",
-              "target": "proptest"
-            },
-            {
-              "id": "reqwest 0.11.12",
-              "target": "reqwest"
-            },
-            {
               "id": "serde 1.0.147",
               "target": "serde"
             },
@@ -12220,6 +12440,10 @@
             {
               "id": "tracing 0.1.37",
               "target": "tracing"
+            },
+            {
+              "id": "url 2.3.1",
+              "target": "url"
             }
           ],
           "selects": {}
@@ -12319,7 +12543,7 @@
               "target": "ed25519_dalek"
             },
             {
-              "id": "fixed 1.19.0",
+              "id": "fixed 1.20.0",
               "target": "fixed"
             },
             {
@@ -12379,7 +12603,7 @@
               "target": "rand"
             },
             {
-              "id": "regex 1.6.0",
+              "id": "regex 1.7.0",
               "target": "regex"
             },
             {
@@ -12493,7 +12717,7 @@
               "target": "coset"
             },
             {
-              "id": "fixed 1.19.0",
+              "id": "fixed 1.20.0",
               "target": "fixed"
             },
             {
@@ -12670,7 +12894,7 @@
               "target": "hex"
             },
             {
-              "id": "num_cpus 1.13.1",
+              "id": "num_cpus 1.14.0",
               "target": "num_cpus"
             },
             {
@@ -12978,13 +13202,13 @@
       },
       "license": "MIT"
     },
-    "native-tls 0.2.10": {
+    "native-tls 0.2.11": {
       "name": "native-tls",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/native-tls/0.2.10/download",
-          "sha256": "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+          "url": "https://crates.io/api/v1/crates/native-tls/0.2.11/download",
+          "sha256": "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
         }
       },
       "targets": [
@@ -13021,7 +13245,7 @@
         "deps": {
           "common": [
             {
-              "id": "native-tls 0.2.10",
+              "id": "native-tls 0.2.11",
               "target": "build_script_build"
             }
           ],
@@ -13075,7 +13299,7 @@
           }
         },
         "edition": "2015",
-        "version": "0.2.10"
+        "version": "0.2.11"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -13610,13 +13834,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "num_cpus 1.13.1": {
+    "num_cpus 1.14.0": {
       "name": "num_cpus",
-      "version": "1.13.1",
+      "version": "1.14.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num_cpus/1.13.1/download",
-          "sha256": "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+          "url": "https://crates.io/api/v1/crates/num_cpus/1.14.0/download",
+          "sha256": "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
         }
       },
       "targets": [
@@ -13656,51 +13880,7 @@
           }
         },
         "edition": "2015",
-        "version": "1.13.1"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "num_threads 0.1.6": {
-      "name": "num_threads",
-      "version": "0.1.6",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/num_threads/0.1.6/download",
-          "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "num_threads",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "num_threads",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(any(target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\"))": [
-              {
-                "id": "libc 0.2.137",
-                "target": "libc"
-              }
-            ]
-          }
-        },
-        "edition": "2015",
-        "version": "0.1.6"
+        "version": "1.14.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -14069,7 +14249,7 @@
               "target": "autocfg"
             },
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             },
             {
@@ -14090,13 +14270,13 @@
       },
       "license": "MIT"
     },
-    "os_str_bytes 6.3.1": {
+    "os_str_bytes 6.4.0": {
       "name": "os_str_bytes",
-      "version": "6.3.1",
+      "version": "6.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.3.1/download",
-          "sha256": "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.4.0/download",
+          "sha256": "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
         }
       },
       "targets": [
@@ -14122,7 +14302,7 @@
           "raw_os_str"
         ],
         "edition": "2021",
-        "version": "6.3.1"
+        "version": "6.4.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -14814,13 +14994,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "pest 2.4.0": {
+    "pest 2.4.1": {
       "name": "pest",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest/2.4.0/download",
-          "sha256": "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
+          "url": "https://crates.io/api/v1/crates/pest/2.4.1/download",
+          "sha256": "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
         }
       },
       "targets": [
@@ -14860,18 +15040,18 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "2.4.0"
+        "edition": "2021",
+        "version": "2.4.1"
       },
       "license": "MIT/Apache-2.0"
     },
-    "pest_derive 2.4.0": {
+    "pest_derive 2.4.1": {
       "name": "pest_derive",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest_derive/2.4.0/download",
-          "sha256": "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
+          "url": "https://crates.io/api/v1/crates/pest_derive/2.4.1/download",
+          "sha256": "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
         }
       },
       "targets": [
@@ -14900,28 +15080,28 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.4.0",
+              "id": "pest 2.4.1",
               "target": "pest"
             },
             {
-              "id": "pest_generator 2.4.0",
+              "id": "pest_generator 2.4.1",
               "target": "pest_generator"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "2.4.0"
+        "edition": "2021",
+        "version": "2.4.1"
       },
       "license": "MIT/Apache-2.0"
     },
-    "pest_generator 2.4.0": {
+    "pest_generator 2.4.1": {
       "name": "pest_generator",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest_generator/2.4.0/download",
-          "sha256": "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
+          "url": "https://crates.io/api/v1/crates/pest_generator/2.4.1/download",
+          "sha256": "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
         }
       },
       "targets": [
@@ -14949,11 +15129,11 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.4.0",
+              "id": "pest 2.4.1",
               "target": "pest"
             },
             {
-              "id": "pest_meta 2.4.0",
+              "id": "pest_meta 2.4.1",
               "target": "pest_meta"
             },
             {
@@ -14971,18 +15151,18 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "2.4.0"
+        "edition": "2021",
+        "version": "2.4.1"
       },
       "license": "MIT/Apache-2.0"
     },
-    "pest_meta 2.4.0": {
+    "pest_meta 2.4.1": {
       "name": "pest_meta",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest_meta/2.4.0/download",
-          "sha256": "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
+          "url": "https://crates.io/api/v1/crates/pest_meta/2.4.1/download",
+          "sha256": "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
         }
       },
       "targets": [
@@ -15011,14 +15191,14 @@
               "target": "once_cell"
             },
             {
-              "id": "pest 2.4.0",
+              "id": "pest 2.4.1",
               "target": "pest"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "2.4.0"
+        "edition": "2021",
+        "version": "2.4.1"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -15517,13 +15697,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "ppv-lite86 0.2.16": {
+    "ppv-lite86 0.2.17": {
       "name": "ppv-lite86",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ppv-lite86/0.2.16/download",
-          "sha256": "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+          "url": "https://crates.io/api/v1/crates/ppv-lite86/0.2.17/download",
+          "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
         }
       },
       "targets": [
@@ -15550,7 +15730,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.2.16"
+        "version": "0.2.17"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -15871,7 +16051,7 @@
               "target": "rand_xorshift"
             },
             {
-              "id": "regex-syntax 0.6.27",
+              "id": "regex-syntax 0.6.28",
               "target": "regex_syntax"
             },
             {
@@ -16352,7 +16532,7 @@
         "deps": {
           "common": [
             {
-              "id": "ppv-lite86 0.2.16",
+              "id": "ppv-lite86 0.2.17",
               "target": "ppv_lite86"
             },
             {
@@ -16401,7 +16581,7 @@
         "deps": {
           "common": [
             {
-              "id": "ppv-lite86 0.2.16",
+              "id": "ppv-lite86 0.2.17",
               "target": "ppv_lite86"
             },
             {
@@ -16636,13 +16816,13 @@
       },
       "license": "MIT"
     },
-    "regex 1.6.0": {
+    "regex 1.7.0": {
       "name": "regex",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex/1.6.0/download",
-          "sha256": "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+          "url": "https://crates.io/api/v1/crates/regex/1.7.0/download",
+          "sha256": "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
         }
       },
       "targets": [
@@ -16694,24 +16874,24 @@
               "target": "memchr"
             },
             {
-              "id": "regex-syntax 0.6.27",
+              "id": "regex-syntax 0.6.28",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.6.0"
+        "version": "1.7.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "regex-syntax 0.6.27": {
+    "regex-syntax 0.6.28": {
       "name": "regex-syntax",
-      "version": "0.6.27",
+      "version": "0.6.28",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex-syntax/0.6.27/download",
-          "sha256": "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+          "url": "https://crates.io/api/v1/crates/regex-syntax/0.6.28/download",
+          "sha256": "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
         }
       },
       "targets": [
@@ -16745,7 +16925,7 @@
           "unicode-segment"
         ],
         "edition": "2018",
-        "version": "0.6.27"
+        "version": "0.6.28"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -16884,7 +17064,7 @@
                 "target": "http_body"
               },
               {
-                "id": "hyper 0.14.20",
+                "id": "hyper 0.14.23",
                 "target": "hyper"
               },
               {
@@ -16892,7 +17072,7 @@
                 "target": "hyper_tls"
               },
               {
-                "id": "ipnet 2.5.0",
+                "id": "ipnet 2.5.1",
                 "target": "ipnet"
               },
               {
@@ -16904,7 +17084,7 @@
                 "target": "mime"
               },
               {
-                "id": "native-tls 0.2.10",
+                "id": "native-tls 0.2.11",
                 "target": "native_tls",
                 "alias": "native_tls_crate"
               },
@@ -17068,7 +17248,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             }
           ],
@@ -18303,13 +18483,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_tokenstream 0.1.3": {
+    "serde_tokenstream 0.1.5": {
       "name": "serde_tokenstream",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_tokenstream/0.1.3/download",
-          "sha256": "d6deb15c3a535e81438110111d90168d91721652f502abb147f31cde129f683d"
+          "url": "https://crates.io/api/v1/crates/serde_tokenstream/0.1.5/download",
+          "sha256": "2794f0ba0179a8ca422c30d9975d86faf8306be0164bfc3b0b1ca4f060ac639d"
         }
       },
       "targets": [
@@ -18348,8 +18528,8 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.1.3"
+        "edition": "2021",
+        "version": "0.1.5"
       },
       "license": "Apache-2.0"
     },
@@ -18624,7 +18804,7 @@
               "target": "digest"
             },
             {
-              "id": "keccak 0.1.2",
+              "id": "keccak 0.1.3",
               "target": "keccak"
             }
           ],
@@ -18678,7 +18858,7 @@
               "target": "digest"
             },
             {
-              "id": "keccak 0.1.2",
+              "id": "keccak 0.1.3",
               "target": "keccak"
             },
             {
@@ -18983,7 +19163,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.16",
+              "id": "time 0.3.17",
               "target": "time"
             }
           ],
@@ -19134,7 +19314,7 @@
               "target": "async_channel"
             },
             {
-              "id": "async-executor 1.4.1",
+              "id": "async-executor 1.5.0",
               "target": "async_executor"
             },
             {
@@ -19486,9 +19666,20 @@
         ],
         "crate_features": [
           "default",
-          "std"
+          "derive",
+          "std",
+          "strum_macros"
         ],
         "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "strum_macros 0.24.3",
+              "target": "strum_macros"
+            }
+          ],
+          "selects": {}
+        },
         "version": "0.24.1"
       },
       "license": "MIT"
@@ -19938,13 +20129,13 @@
       },
       "license": "MIT"
     },
-    "target-lexicon 0.12.4": {
+    "target-lexicon 0.12.5": {
       "name": "target-lexicon",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/target-lexicon/0.12.4/download",
-          "sha256": "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+          "url": "https://crates.io/api/v1/crates/target-lexicon/0.12.5/download",
+          "sha256": "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
         }
       },
       "targets": [
@@ -19984,14 +20175,14 @@
         "deps": {
           "common": [
             {
-              "id": "target-lexicon 0.12.4",
+              "id": "target-lexicon 0.12.5",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.12.4"
+        "version": "0.12.5"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -20173,7 +20364,7 @@
               "target": "tendermint_proto"
             },
             {
-              "id": "time 0.3.16",
+              "id": "time 0.3.17",
               "target": "time"
             },
             {
@@ -20399,7 +20590,7 @@
               "target": "subtle_encoding"
             },
             {
-              "id": "time 0.3.16",
+              "id": "time 0.3.17",
               "target": "time"
             }
           ],
@@ -20494,7 +20685,7 @@
               "target": "http"
             },
             {
-              "id": "hyper 0.14.20",
+              "id": "hyper 0.14.23",
               "target": "hyper"
             },
             {
@@ -20550,7 +20741,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.16",
+              "id": "time 0.3.17",
               "target": "time"
             },
             {
@@ -20919,13 +21110,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "time 0.3.16": {
+    "time 0.3.17": {
       "name": "time",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time/0.3.16/download",
-          "sha256": "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+          "url": "https://crates.io/api/v1/crates/time/0.3.17/download",
+          "sha256": "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
         }
       },
       "targets": [
@@ -20970,30 +21161,19 @@
               "target": "time_core"
             }
           ],
-          "selects": {
-            "cfg(target_family = \"unix\")": [
-              {
-                "id": "libc 0.2.137",
-                "target": "libc"
-              },
-              {
-                "id": "num_threads 0.1.6",
-                "target": "num_threads"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
         "proc_macro_deps": {
           "common": [
             {
-              "id": "time-macros 0.2.5",
+              "id": "time-macros 0.2.6",
               "target": "time_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.16"
+        "version": "0.3.17"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -21030,13 +21210,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "time-macros 0.2.5": {
+    "time-macros 0.2.6": {
       "name": "time-macros",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time-macros/0.2.5/download",
-          "sha256": "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+          "url": "https://crates.io/api/v1/crates/time-macros/0.2.6/download",
+          "sha256": "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
         }
       },
       "targets": [
@@ -21072,7 +21252,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.5"
+        "version": "0.2.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -21122,7 +21302,7 @@
               "target": "log"
             },
             {
-              "id": "time 0.3.16",
+              "id": "time 0.3.17",
               "target": "time"
             },
             {
@@ -21297,7 +21477,7 @@
               "target": "mio"
             },
             {
-              "id": "num_cpus 1.13.1",
+              "id": "num_cpus 1.14.0",
               "target": "num_cpus"
             },
             {
@@ -21447,7 +21627,7 @@
         "deps": {
           "common": [
             {
-              "id": "native-tls 0.2.10",
+              "id": "native-tls 0.2.11",
               "target": "native_tls"
             },
             {
@@ -22785,7 +22965,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.16",
+              "id": "time 0.3.17",
               "target": "time"
             },
             {
@@ -22818,7 +22998,7 @@
               "target": "anyhow"
             },
             {
-              "id": "time 0.3.16",
+              "id": "time 0.3.17",
               "target": "time"
             }
           ],
@@ -23761,7 +23941,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             }
           ],
@@ -25225,7 +25405,7 @@
   "binary_crates": [
     "bindgen 0.59.2",
     "bindgen 0.60.1",
-    "cc 1.0.74",
+    "cc 1.0.76",
     "clap 3.2.23",
     "minicbor 0.18.0",
     "peg-macros 0.7.0",
@@ -25235,7 +25415,6 @@
     "webpki-roots 0.21.1"
   ],
   "workspace_members": {
-    "direct-cargo-bazel-deps 0.0.1": "",
     "http_proxy 0.1.0": "src/http_proxy",
     "idstore-export 0.1.0": "src/idstore-export",
     "kvstore 0.1.0": "src/kvstore",
@@ -25360,16 +25539,6 @@
       "i686-apple-darwin",
       "x86_64-apple-darwin",
       "x86_64-apple-ios"
-    ],
-    "cfg(any(target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\"))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "i686-apple-darwin",
-      "i686-unknown-freebsd",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-unknown-freebsd"
     ],
     "cfg(any(unix, target_os = \"fuchsia\", target_os = \"vxworks\"))": [
       "aarch64-apple-darwin",
@@ -25569,6 +25738,13 @@
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
     ],
+    "cfg(target_arch = \"aarch64\")": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu"
+    ],
     "cfg(target_arch = \"spirv\")": [],
     "cfg(target_arch = \"wasm32\")": [
       "wasm32-unknown-unknown",
@@ -25577,27 +25753,6 @@
     "cfg(target_env = \"msvc\")": [
       "i686-pc-windows-msvc",
       "x86_64-pc-windows-msvc"
-    ],
-    "cfg(target_family = \"unix\")": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-linux-android",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
-      "powerpc-unknown-linux-gnu",
-      "s390x-unknown-linux-gnu",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-linux-android",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu"
     ],
     "cfg(target_feature = \"atomics\")": [],
     "cfg(target_os = \"emscripten\")": [],

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -27,7 +27,7 @@ merk = { git = "https://github.com/liftedinit/merk.git", rev = "da0b660abbfd58ab
 hex = "0.4.3"
 itertools = "0.10.3"
 json5 = "0.4.1"
-linkme = "0.3.5"
+linkme = { version = "0.3.5", features = ["used_linker"] }
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }

--- a/src/many-ledger/src/lib.rs
+++ b/src/many-ledger/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(used_with_arg)]
+
 extern crate core;
 
 pub mod error;

--- a/src/many-ledger/src/main.rs
+++ b/src/many-ledger/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(used_with_arg)]
+
 use clap::Parser;
 use many_identity::verifiers::AnonymousVerifier;
 use many_identity::{Address, Identity};


### PR DESCRIPTION
- Update Bazel rules_rust to 0.13
- Pin Bazel Rust nightly to 2022-11-13
- Fix `linkme` linker error (Bazel)