### PR TITLE
Refactor the Memo field into a legacy memo and ng memo

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -97,11 +97,11 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
- "concurrent-queue 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "concurrent-queue",
  "event-listener",
  "futures-core",
 ]
@@ -114,7 +114,7 @@ checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
  "async-lock",
  "async-task",
- "concurrent-queue 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "concurrent-queue",
  "fastrand",
  "futures-lite",
  "slab",
@@ -134,13 +134,13 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
 dependencies = [
  "async-lock",
  "autocfg",
- "concurrent-queue 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "concurrent-queue",
  "futures-lite",
  "libc",
  "log",
@@ -149,7 +149,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "winapi",
+ "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -176,20 +176,20 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
+checksum = "6381ead98388605d0d9ff86371043b5aa922a3905824244de40dc263a14fcba4"
 dependencies = [
  "async-io",
+ "async-lock",
  "autocfg",
  "blocking",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "event-listener",
  "futures-lite",
  "libc",
- "once_cell",
  "signal-hook",
- "winapi",
+ "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,9 +200,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -386,16 +386,16 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
 dependencies = [
  "async-channel",
+ "async-lock",
  "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -435,12 +435,6 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
@@ -595,15 +589,6 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
-dependencies = [
- "cache-padded",
 ]
 
 [[package]]
@@ -1946,18 +1931,18 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab56277eeaacac09e1398bcefc113319c6c8d4fb464f11c54ba247cdb65776e"
+checksum = "c25ef733283514e2c267f019701d6c81537e5d1807d6b1d7ef17f17585db964b"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624b78e5a5f99b2c751812a14785a2c661f894a34bc3dd1f2ec3e3fffb4605e7"
+checksum = "2a82efd9655156d970e99312fd3a613b4be4f169b4c35f4463b7499a40d3ed24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2024,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2067,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2077,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2088,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "base32",
  "coset",
@@ -2108,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "asn1 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "base32",
@@ -2136,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "asn1 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "coset",
@@ -2156,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "coset",
@@ -2259,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2272,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "many-error",
  "minicbor",
@@ -2285,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "async-trait",
  "coset",
@@ -2305,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "coset",
@@ -2329,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "anyhow",
  "asn1 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2378,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "coset",
  "fixed",
@@ -2587,9 +2572,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2619,9 +2604,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
 dependencies = [
  "autocfg",
  "cc",
@@ -2671,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -2765,9 +2750,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2775,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
+checksum = "423c2ba011d6e27b02b482a3707c773d19aec65cc024637aec44e19652e66f63"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2785,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+checksum = "3e64e6c2c85031c02fdbd9e5c72845445ca0a724d419aa0bc068ac620c9935c1"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2798,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+checksum = "57959b91f0a133f89a68be874a5c88ed689c19cd729ecdb5d762ebf16c64d662"
 dependencies = [
  "once_cell",
  "pest",
@@ -2888,16 +2873,16 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
+checksum = "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
  "log",
  "wepoll-ffi",
- "winapi",
+ "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3353,9 +3338,9 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
@@ -3371,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3555,9 +3540,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol"
-version = "1.2.5"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf3b5351f3e783c1d79ab5fc604eeed8b8ae9abd36b166e8b87a089efd85e4"
+checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -3568,7 +3553,6 @@ dependencies = [
  "async-process",
  "blocking",
  "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -3669,9 +3653,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3692,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375d5fd899e32847b8566e10598d6e9f1d9b55ec6de3cdf9e7da4bdc51371bc"
+checksum = "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys",
@@ -3983,9 +3967,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4227,9 +4211,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.4.2"
+version = "7.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+checksum = "447f9238a4553957277b3ee09d80babeae0811f1b3baefb093de1c0448437a37"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4572,15 +4556,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "many"
-version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
-
-
-[[patch.unused]]
-name = "many-mock"
-version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
-

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -418,9 +418,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 dependencies = [
  "serde",
 ]
@@ -444,9 +444,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
 ]
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-common",
@@ -1539,7 +1539,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1712,9 +1712,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1879,6 +1879,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ledger-db"
+version = "0.1.0"
+dependencies = [
+ "clap 3.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "many-modules",
+ "many-types",
+ "merk",
+ "minicbor",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,7 +2024,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2055,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2065,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2076,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "base32",
  "coset",
@@ -2096,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "asn1 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "base32",
@@ -2124,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "asn1 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "coset",
@@ -2144,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "coset",
@@ -2247,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2260,8 +2272,9 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
+ "many-error",
  "minicbor",
  "serde",
  "serde_json",
@@ -2272,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "async-trait",
  "coset",
@@ -2292,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "coset",
@@ -2316,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "anyhow",
  "asn1 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2365,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=539f8aa33c8c8f10872373bf5665d20fafb8a7a6#539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "coset",
  "fixed",
@@ -2619,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"
@@ -2690,7 +2703,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
- "digest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3117,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
@@ -3369,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -3420,7 +3433,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpufeatures",
- "digest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3444,7 +3457,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpufeatures",
- "digest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3465,7 +3478,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak",
 ]
 
@@ -3950,9 +3963,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4559,3 +4572,15 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "many"
+version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+
+
+[[patch.unused]]
+name = "many-mock"
+version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,6 +2024,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2066,6 +2067,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2075,6 +2077,7 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2085,6 +2088,7 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "base32",
  "coset",
@@ -2104,6 +2108,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "asn1 0.8.7",
  "base32",
@@ -2131,6 +2136,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "asn1 0.10.0",
  "coset",
@@ -2150,6 +2156,7 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2252,6 +2259,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2264,6 +2272,7 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "many-error",
  "minicbor",
@@ -2276,6 +2285,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "async-trait",
  "coset",
@@ -2295,6 +2305,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2318,6 +2329,7 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "anyhow",
  "asn1 0.11.0",
@@ -2366,6 +2378,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 dependencies = [
  "coset",
  "fixed",
@@ -4563,7 +4576,9 @@ dependencies = [
 [[patch.unused]]
 name = "many"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
 
 [[patch.unused]]
 name = "many-mock"
 version = "0.1.0"
+source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,6 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2052,7 +2051,6 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2062,7 +2060,6 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2073,7 +2070,6 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "base32",
  "coset",
@@ -2093,7 +2089,6 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "asn1 0.8.7",
  "base32",
@@ -2121,7 +2116,6 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "asn1 0.10.0",
  "coset",
@@ -2141,7 +2135,6 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2244,7 +2237,6 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2257,7 +2249,6 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "minicbor",
  "serde",
@@ -2269,7 +2260,6 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "async-trait",
  "coset",
@@ -2289,7 +2279,6 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2313,7 +2302,6 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "anyhow",
  "asn1 0.11.0",
@@ -2362,7 +2350,6 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=207ca9fdd0e403b758a3a31752ab98daac14e980#207ca9fdd0e403b758a3a31752ab98daac14e980"
 dependencies = [
  "coset",
  "fixed",
@@ -4556,3 +4543,11 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "many"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "many-mock"
+version = "0.1.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,6 +1876,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ledger-db"
+version = "0.1.0"
+dependencies = [
+ "clap 3.2.23",
+ "hex",
+ "many-modules",
+ "many-types",
+ "merk",
+ "minicbor",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2262,7 @@ dependencies = [
 name = "many-migration"
 version = "0.1.0"
 dependencies = [
+ "many-error",
  "minicbor",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,11 +97,11 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
- "concurrent-queue 1.2.4",
+ "concurrent-queue",
  "event-listener",
  "futures-core",
 ]
@@ -114,7 +114,7 @@ checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
  "async-lock",
  "async-task",
- "concurrent-queue 2.0.0",
+ "concurrent-queue",
  "fastrand",
  "futures-lite",
  "slab",
@@ -134,13 +134,13 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
 dependencies = [
  "async-lock",
  "autocfg",
- "concurrent-queue 1.2.4",
+ "concurrent-queue",
  "futures-lite",
  "libc",
  "log",
@@ -149,7 +149,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -176,20 +176,20 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
+checksum = "6381ead98388605d0d9ff86371043b5aa922a3905824244de40dc263a14fcba4"
 dependencies = [
  "async-io",
+ "async-lock",
  "autocfg",
  "blocking",
  "cfg-if 1.0.0",
  "event-listener",
  "futures-lite",
  "libc",
- "once_cell",
  "signal-hook",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -200,9 +200,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -386,16 +386,16 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
 dependencies = [
  "async-channel",
+ "async-lock",
  "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -435,12 +435,6 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
@@ -595,15 +589,6 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
-dependencies = [
- "cache-padded",
 ]
 
 [[package]]
@@ -1946,18 +1931,18 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab56277eeaacac09e1398bcefc113319c6c8d4fb464f11c54ba247cdb65776e"
+checksum = "c25ef733283514e2c267f019701d6c81537e5d1807d6b1d7ef17f17585db964b"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624b78e5a5f99b2c751812a14785a2c661f894a34bc3dd1f2ec3e3fffb4605e7"
+checksum = "2a82efd9655156d970e99312fd3a613b4be4f169b4c35f4463b7499a40d3ed24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2024,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2067,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2077,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2088,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "base32",
  "coset",
@@ -2108,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "asn1 0.8.7",
  "base32",
@@ -2136,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "asn1 0.10.0",
  "coset",
@@ -2156,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2259,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2272,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "many-error",
  "minicbor",
@@ -2285,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "async-trait",
  "coset",
@@ -2305,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2329,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "anyhow",
  "asn1 0.11.0",
@@ -2378,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=ab09727a574d3abe734a374cd02e31aa6b3388f7#ab09727a574d3abe734a374cd02e31aa6b3388f7"
 dependencies = [
  "coset",
  "fixed",
@@ -2587,9 +2572,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2619,9 +2604,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
 dependencies = [
  "autocfg",
  "cc",
@@ -2671,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -2765,9 +2750,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2775,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
+checksum = "423c2ba011d6e27b02b482a3707c773d19aec65cc024637aec44e19652e66f63"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2785,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+checksum = "3e64e6c2c85031c02fdbd9e5c72845445ca0a724d419aa0bc068ac620c9935c1"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2798,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+checksum = "57959b91f0a133f89a68be874a5c88ed689c19cd729ecdb5d762ebf16c64d662"
 dependencies = [
  "once_cell",
  "pest",
@@ -2888,16 +2873,16 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
+checksum = "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-ffi",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3353,9 +3338,9 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
@@ -3371,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3555,9 +3540,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol"
-version = "1.2.5"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf3b5351f3e783c1d79ab5fc604eeed8b8ae9abd36b166e8b87a089efd85e4"
+checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -3568,7 +3553,6 @@ dependencies = [
  "async-process",
  "blocking",
  "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -3669,9 +3653,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3692,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375d5fd899e32847b8566e10598d6e9f1d9b55ec6de3cdf9e7da4bdc51371bc"
+checksum = "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -3983,9 +3967,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4227,9 +4211,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.4.2"
+version = "7.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+checksum = "447f9238a4553957277b3ee09d80babeae0811f1b3baefb093de1c0448437a37"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4572,13 +4556,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "many"
-version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
-
-[[patch.unused]]
-name = "many-mock"
-version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422f23e724af1240ec469ea1e834d87a4b59ce2efe2c6a96256b0c47e2fd86aa"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -2024,7 +2024,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2077,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "base32",
  "coset",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "asn1 0.8.7",
  "base32",
@@ -2136,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "asn1 0.10.0",
  "coset",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2259,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "many-error",
  "minicbor",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "async-trait",
  "coset",
@@ -2305,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2329,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "anyhow",
  "asn1 0.11.0",
@@ -2378,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 dependencies = [
  "coset",
  "fixed",
@@ -3382,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8b3801309262e8184d9687fb697586833e939767aea0dda89f5a8e650e8bd7"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -4576,9 +4576,9 @@ dependencies = [
 [[patch.unused]]
 name = "many"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"
 
 [[patch.unused]]
 name = "many-mock"
 version = "0.1.0"
-source = "git+https://github.com/hansl/many-rs.git?rev=fe48cf7cc75745317d7fadc88f286e7331638853#fe48cf7cc75745317d7fadc88f286e7331638853"
+source = "git+https://github.com/hansl/many-rs.git?branch=memo-refactor#817be3b05dfc61029dd1c22e1667238329b1d415"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,23 +38,6 @@ incremental = false
 #many-server = { path = "../many-rs/src/many-server" }
 #many-types = { path = "../many-rs/src/many-types" }
 
-[patch."https://github.com/liftedinit/many-rs.git"]
-many = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-client = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-client-macros = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-error = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-identity = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-identity-dsa = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-identity-hsm = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-identity-webauthn = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-macros = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-migration = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-mock = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-modules = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-protocol = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-server = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-many-types = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
-
 [patch.crates-io]
 ciborium = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }
 ciborium-io = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "src/http_proxy",
     "src/idstore-export",
     "src/ledger",
+    "src/ledger-db",
     "src/kvstore",
     "src/many-abci",
     "src/many-kvstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,22 +19,22 @@ incremental = false
 [profile.dev]
 incremental = false
 
-#[patch."https://github.com/liftedinit/many-rs.git"]
-#many = { path = "../many-rs/src/many" }
-#many-client = { path = "../many-rs/src/many-client" }
-#many-client-macros = { path = "../many-rs/src/many-client-macros" }
-#many-error = { path = "../many-rs/src/many-error" }
-#many-identity = { path = "../many-rs/src/many-identity" }
-#many-identity-dsa = { path = "../many-rs/src/many-identity-dsa" }
-#many-identity-hsm = { path = "../many-rs/src/many-identity-hsm" }
-#many-identity-webauthn = { path = "../many-rs/src/many-identity-webauthn" }
-#many-macros = { path = "../many-rs/src/many-macros" }
-#many-migration = { path = "../many-rs/src/many-migration" }
-#many-mock = { path = "../many-rs/src/many-mock" }
-#many-modules = { path = "../many-rs/src/many-modules" }
-#many-protocol = { path = "../many-rs/src/many-protocol" }
-#many-server = { path = "../many-rs/src/many-server" }
-#many-types = { path = "../many-rs/src/many-types" }
+[patch."https://github.com/liftedinit/many-rs.git"]
+many = { path = "../many-rs/src/many" }
+many-client = { path = "../many-rs/src/many-client" }
+many-client-macros = { path = "../many-rs/src/many-client-macros" }
+many-error = { path = "../many-rs/src/many-error" }
+many-identity = { path = "../many-rs/src/many-identity" }
+many-identity-dsa = { path = "../many-rs/src/many-identity-dsa" }
+many-identity-hsm = { path = "../many-rs/src/many-identity-hsm" }
+many-identity-webauthn = { path = "../many-rs/src/many-identity-webauthn" }
+many-macros = { path = "../many-rs/src/many-macros" }
+many-migration = { path = "../many-rs/src/many-migration" }
+many-mock = { path = "../many-rs/src/many-mock" }
+many-modules = { path = "../many-rs/src/many-modules" }
+many-protocol = { path = "../many-rs/src/many-protocol" }
+many-server = { path = "../many-rs/src/many-server" }
+many-types = { path = "../many-rs/src/many-types" }
 
 [patch.crates-io]
 ciborium = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,22 +21,39 @@ incremental = false
 [profile.dev]
 incremental = false
 
+#[patch."https://github.com/liftedinit/many-rs.git"]
+#many = { path = "../many-rs/src/many" }
+#many-client = { path = "../many-rs/src/many-client" }
+#many-client-macros = { path = "../many-rs/src/many-client-macros" }
+#many-error = { path = "../many-rs/src/many-error" }
+#many-identity = { path = "../many-rs/src/many-identity" }
+#many-identity-dsa = { path = "../many-rs/src/many-identity-dsa" }
+#many-identity-hsm = { path = "../many-rs/src/many-identity-hsm" }
+#many-identity-webauthn = { path = "../many-rs/src/many-identity-webauthn" }
+#many-macros = { path = "../many-rs/src/many-macros" }
+#many-migration = { path = "../many-rs/src/many-migration" }
+#many-mock = { path = "../many-rs/src/many-mock" }
+#many-modules = { path = "../many-rs/src/many-modules" }
+#many-protocol = { path = "../many-rs/src/many-protocol" }
+#many-server = { path = "../many-rs/src/many-server" }
+#many-types = { path = "../many-rs/src/many-types" }
+
 [patch."https://github.com/liftedinit/many-rs.git"]
-many = { path = "../many-rs/src/many" }
-many-client = { path = "../many-rs/src/many-client" }
-many-client-macros = { path = "../many-rs/src/many-client-macros" }
-many-error = { path = "../many-rs/src/many-error" }
-many-identity = { path = "../many-rs/src/many-identity" }
-many-identity-dsa = { path = "../many-rs/src/many-identity-dsa" }
-many-identity-hsm = { path = "../many-rs/src/many-identity-hsm" }
-many-identity-webauthn = { path = "../many-rs/src/many-identity-webauthn" }
-many-macros = { path = "../many-rs/src/many-macros" }
-many-migration = { path = "../many-rs/src/many-migration" }
-many-mock = { path = "../many-rs/src/many-mock" }
-many-modules = { path = "../many-rs/src/many-modules" }
-many-protocol = { path = "../many-rs/src/many-protocol" }
-many-server = { path = "../many-rs/src/many-server" }
-many-types = { path = "../many-rs/src/many-types" }
+many = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-client = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-client-macros = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-error = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-identity = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-identity-dsa = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-identity-hsm = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-identity-webauthn = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-macros = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-migration = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-mock = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-modules = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-protocol = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-server = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many-types = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
 
 [patch.crates-io]
 ciborium = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,21 +39,21 @@ incremental = false
 #many-types = { path = "../many-rs/src/many-types" }
 
 [patch."https://github.com/liftedinit/many-rs.git"]
-many = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-client = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-client-macros = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-error = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-identity = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-identity-dsa = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-identity-hsm = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-identity-webauthn = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-macros = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-migration = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-mock = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-modules = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-protocol = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-server = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
-many-types = { git = "https://github.com/hansl/many-rs.git", rev = "fe48cf7cc75745317d7fadc88f286e7331638853" }
+many = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-client = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-client-macros = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-error = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-identity = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-identity-dsa = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-identity-hsm = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-identity-webauthn = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-macros = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-migration = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-mock = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-modules = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-protocol = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-server = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
+many-types = { git = "https://github.com/hansl/many-rs.git", branch = "memo-refactor" }
 
 [patch.crates-io]
 ciborium = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -49,6 +49,7 @@ crates_repository(
         "//src/idstore-export:Cargo.toml",
         "//src/kvstore:Cargo.toml",
         "//src/ledger:Cargo.toml",
+        "//src/ledger-db:Cargo.toml",
         "//src/many-abci:Cargo.toml",
         "//src/many-kvstore:Cargo.toml",
         "//src/many-ledger:Cargo.toml",

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "67ac4227c8f0b31d984f69751735510e784219a59fd6b70a7cd742d14e4aaaec",
+  "checksum": "aa469f62b4563a29f28484621b180e2c2aa3e766304f7428b1cf1488b0b20067",
   "crates": {
     "aes 0.7.5": {
       "name": "aes",
@@ -499,7 +499,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -510,13 +510,13 @@
       },
       "license": "BSD-3-Clause"
     },
-    "async-channel 1.7.1": {
+    "async-channel 1.8.0": {
       "name": "async-channel",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-channel/1.7.1/download",
-          "sha256": "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+          "url": "https://crates.io/api/v1/crates/async-channel/1.8.0/download",
+          "sha256": "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
         }
       },
       "targets": [
@@ -541,7 +541,7 @@
         "deps": {
           "common": [
             {
-              "id": "concurrent-queue 1.2.4",
+              "id": "concurrent-queue 2.0.0",
               "target": "concurrent_queue"
             },
             {
@@ -556,7 +556,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.7.1"
+        "version": "1.8.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -673,7 +673,7 @@
               "target": "async_lock"
             },
             {
-              "id": "blocking 1.2.0",
+              "id": "blocking 1.3.0",
               "target": "blocking"
             },
             {
@@ -702,13 +702,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-io 1.10.0": {
+    "async-io 1.12.0": {
       "name": "async-io",
-      "version": "1.10.0",
+      "version": "1.12.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-io/1.10.0/download",
-          "sha256": "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
+          "url": "https://crates.io/api/v1/crates/async-io/1.12.0/download",
+          "sha256": "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
         }
       },
       "targets": [
@@ -745,7 +745,7 @@
         "deps": {
           "common": [
             {
-              "id": "async-io 1.10.0",
+              "id": "async-io 1.12.0",
               "target": "build_script_build"
             },
             {
@@ -753,7 +753,7 @@
               "target": "async_lock"
             },
             {
-              "id": "concurrent-queue 1.2.4",
+              "id": "concurrent-queue 2.0.0",
               "target": "concurrent_queue"
             },
             {
@@ -769,7 +769,7 @@
               "target": "parking"
             },
             {
-              "id": "polling 2.4.0",
+              "id": "polling 2.5.1",
               "target": "polling"
             },
             {
@@ -794,14 +794,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
+                "id": "windows-sys 0.42.0",
+                "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "1.10.0"
+        "version": "1.12.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -908,7 +908,7 @@
         "deps": {
           "common": [
             {
-              "id": "async-io 1.10.0",
+              "id": "async-io 1.12.0",
               "target": "async_io"
             },
             {
@@ -916,7 +916,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "blocking 1.2.0",
+              "id": "blocking 1.3.0",
               "target": "blocking"
             },
             {
@@ -945,13 +945,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-process 1.5.0": {
+    "async-process 1.6.0": {
       "name": "async-process",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-process/1.5.0/download",
-          "sha256": "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
+          "url": "https://crates.io/api/v1/crates/async-process/1.6.0/download",
+          "sha256": "6381ead98388605d0d9ff86371043b5aa922a3905824244de40dc263a14fcba4"
         }
       },
       "targets": [
@@ -988,7 +988,11 @@
         "deps": {
           "common": [
             {
-              "id": "async-process 1.5.0",
+              "id": "async-lock 2.6.0",
+              "target": "async_lock"
+            },
+            {
+              "id": "async-process 1.6.0",
               "target": "build_script_build"
             },
             {
@@ -1002,16 +1006,12 @@
             {
               "id": "futures-lite 1.12.0",
               "target": "futures_lite"
-            },
-            {
-              "id": "once_cell 1.16.0",
-              "target": "once_cell"
             }
           ],
           "selects": {
             "cfg(unix)": [
               {
-                "id": "async-io 1.10.0",
+                "id": "async-io 1.12.0",
                 "target": "async_io"
               },
               {
@@ -1025,18 +1025,18 @@
             ],
             "cfg(windows)": [
               {
-                "id": "blocking 1.2.0",
+                "id": "blocking 1.3.0",
                 "target": "blocking"
               },
               {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
+                "id": "windows-sys 0.42.0",
+                "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1091,13 +1091,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-trait 0.1.58": {
+    "async-trait 0.1.59": {
       "name": "async-trait",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-trait/0.1.58/download",
-          "sha256": "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+          "url": "https://crates.io/api/v1/crates/async-trait/0.1.59/download",
+          "sha256": "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
         }
       },
       "targets": [
@@ -1134,7 +1134,7 @@
         "deps": {
           "common": [
             {
-              "id": "async-trait 0.1.58",
+              "id": "async-trait 0.1.59",
               "target": "build_script_build"
             },
             {
@@ -1146,14 +1146,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.58"
+        "version": "0.1.59"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2175,13 +2175,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "blocking 1.2.0": {
+    "blocking 1.3.0": {
       "name": "blocking",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/blocking/1.2.0/download",
-          "sha256": "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+          "url": "https://crates.io/api/v1/crates/blocking/1.3.0/download",
+          "sha256": "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
         }
       },
       "targets": [
@@ -2206,8 +2206,12 @@
         "deps": {
           "common": [
             {
-              "id": "async-channel 1.7.1",
+              "id": "async-channel 1.8.0",
               "target": "async_channel"
+            },
+            {
+              "id": "async-lock 2.6.0",
+              "target": "async_lock"
             },
             {
               "id": "async-task 4.3.0",
@@ -2224,16 +2228,12 @@
             {
               "id": "futures-lite 1.12.0",
               "target": "futures_lite"
-            },
-            {
-              "id": "once_cell 1.16.0",
-              "target": "once_cell"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.2.0"
+        "version": "1.3.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -2380,7 +2380,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -2470,39 +2470,6 @@
         "links": "bzip2"
       },
       "license": "MIT/Apache-2.0"
-    },
-    "cache-padded 1.2.0": {
-      "name": "cache-padded",
-      "version": "1.2.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/cache-padded/1.2.0/download",
-          "sha256": "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "cache_padded",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "cache_padded",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "1.2.0"
-      },
-      "license": "Apache-2.0 OR MIT"
     },
     "cc 1.0.77": {
       "name": "cc",
@@ -2798,7 +2765,7 @@
               "target": "ciborium_ll"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -3264,7 +3231,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -3369,48 +3336,6 @@
         "version": "1.9.3"
       },
       "license": "MPL-2.0"
-    },
-    "concurrent-queue 1.2.4": {
-      "name": "concurrent-queue",
-      "version": "1.2.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/concurrent-queue/1.2.4/download",
-          "sha256": "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "concurrent_queue",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "concurrent_queue",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cache-padded 1.2.0",
-              "target": "cache_padded"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.2.4"
-      },
-      "license": "Apache-2.0 OR MIT"
     },
     "concurrent-queue 2.0.0": {
       "name": "concurrent-queue",
@@ -4472,7 +4397,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -4774,7 +4699,7 @@
               "target": "strsim"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -4840,7 +4765,7 @@
               "target": "strsim"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -4890,7 +4815,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -4940,7 +4865,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -5124,7 +5049,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -5270,7 +5195,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -5324,7 +5249,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -5370,7 +5295,7 @@
               "target": "derive_builder_core"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -5416,7 +5341,7 @@
               "target": "derive_builder_core"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -5691,7 +5616,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -5857,7 +5782,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde",
               "alias": "serde_crate"
             },
@@ -6180,7 +6105,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -6306,7 +6231,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -7220,7 +7145,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -7720,7 +7645,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -7770,7 +7695,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -8347,7 +8272,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -9223,7 +9148,7 @@
               "target": "merk"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -9237,7 +9162,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.147",
+              "id": "serde_derive 1.0.148",
               "target": "serde_derive"
             }
           ],
@@ -9769,11 +9694,11 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.4.1",
+              "id": "pest 2.5.0",
               "target": "pest"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -9783,7 +9708,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "pest_derive 2.4.1",
+              "id": "pest_derive 2.5.0",
               "target": "pest_derive"
             }
           ],
@@ -10562,13 +10487,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "linkme 0.3.5": {
+    "linkme 0.3.6": {
       "name": "linkme",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/linkme/0.3.5/download",
-          "sha256": "cab56277eeaacac09e1398bcefc113319c6c8d4fb464f11c54ba247cdb65776e"
+          "url": "https://crates.io/api/v1/crates/linkme/0.3.6/download",
+          "sha256": "c25ef733283514e2c267f019701d6c81537e5d1807d6b1d7ef17f17585db964b"
         }
       },
       "targets": [
@@ -10597,23 +10522,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "linkme-impl 0.3.5",
+              "id": "linkme-impl 0.3.6",
               "target": "linkme_impl"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.5"
+        "version": "0.3.6"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "linkme-impl 0.3.5": {
+    "linkme-impl 0.3.6": {
       "name": "linkme-impl",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/linkme-impl/0.3.5/download",
-          "sha256": "624b78e5a5f99b2c751812a14785a2c661f894a34bc3dd1f2ec3e3fffb4605e7"
+          "url": "https://crates.io/api/v1/crates/linkme-impl/0.3.6/download",
+          "sha256": "2a82efd9655156d970e99312fd3a613b4be4f169b4c35f4463b7499a40d3ed24"
         }
       },
       "targets": [
@@ -10649,14 +10574,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.5"
+        "version": "0.3.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -10936,7 +10861,7 @@
               "target": "signal_hook"
             },
             {
-              "id": "smol 1.2.5",
+              "id": "smol 1.3.0",
               "target": "smol"
             },
             {
@@ -10978,7 +10903,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.58",
+              "id": "async-trait 0.1.59",
               "target": "async_trait"
             }
           ],
@@ -10993,7 +10918,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.4.2",
+              "id": "vergen 7.4.3",
               "target": "vergen"
             }
           ],
@@ -11007,9 +10932,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-client"
         }
@@ -11143,7 +11068,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -11177,7 +11102,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.58",
+              "id": "async-trait 0.1.59",
               "target": "async_trait"
             },
             {
@@ -11200,9 +11125,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-client-macros"
         }
@@ -11237,7 +11162,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -11253,9 +11178,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-error"
         }
@@ -11319,9 +11244,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-identity"
         }
@@ -11384,7 +11309,7 @@
               "target": "once_cell"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -11420,9 +11345,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-identity-dsa"
         }
@@ -11522,7 +11447,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -11554,9 +11479,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-identity-hsm"
         }
@@ -11647,9 +11572,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-identity-webauthn"
         }
@@ -11708,7 +11633,7 @@
               "target": "once_cell"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -11849,7 +11774,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -11908,7 +11833,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.58",
+              "id": "async-trait 0.1.59",
               "target": "async_trait"
             }
           ],
@@ -11923,7 +11848,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.4.2",
+              "id": "vergen 7.4.3",
               "target": "vergen"
             }
           ],
@@ -12018,7 +11943,7 @@
               "target": "json5"
             },
             {
-              "id": "linkme 0.3.5",
+              "id": "linkme 0.3.6",
               "target": "linkme"
             },
             {
@@ -12082,7 +12007,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -12157,7 +12082,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.58",
+              "id": "async-trait 0.1.59",
               "target": "async_trait"
             }
           ],
@@ -12172,7 +12097,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.4.2",
+              "id": "vergen 7.4.3",
               "target": "vergen"
             }
           ],
@@ -12186,9 +12111,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-macros"
         }
@@ -12227,7 +12152,7 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -12235,7 +12160,7 @@
               "target": "serde_tokenstream"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -12251,9 +12176,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-migration"
         }
@@ -12288,7 +12213,7 @@
               "target": "minicbor"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -12316,9 +12241,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-modules"
         }
@@ -12391,7 +12316,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.58",
+              "id": "async-trait 0.1.59",
               "target": "async_trait"
             },
             {
@@ -12414,9 +12339,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-protocol"
         }
@@ -12483,7 +12408,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -12528,9 +12453,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-server"
         }
@@ -12672,7 +12597,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -12718,7 +12643,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.58",
+              "id": "async-trait 0.1.59",
               "target": "async_trait"
             },
             {
@@ -12745,9 +12670,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/hansl/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "memo-refactor"
+            "Rev": "ab09727a574d3abe734a374cd02e31aa6b3388f7"
           },
           "strip_prefix": "src/many-types"
         }
@@ -12806,7 +12731,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -13145,7 +13070,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -13339,7 +13264,7 @@
                 "target": "log"
               },
               {
-                "id": "openssl 0.10.42",
+                "id": "openssl 0.10.43",
                 "target": "openssl"
               },
               {
@@ -13347,7 +13272,7 @@
                 "target": "openssl_probe"
               },
               {
-                "id": "openssl-sys 0.9.77",
+                "id": "openssl-sys 0.9.78",
                 "target": "openssl_sys"
               }
             ],
@@ -13734,7 +13659,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -14054,13 +13979,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "openssl 0.10.42": {
+    "openssl 0.10.43": {
       "name": "openssl",
-      "version": "0.10.42",
+      "version": "0.10.43",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/openssl/0.10.42/download",
-          "sha256": "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+          "url": "https://crates.io/api/v1/crates/openssl/0.10.43/download",
+          "sha256": "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
         }
       },
       "targets": [
@@ -14120,11 +14045,11 @@
               "target": "once_cell"
             },
             {
-              "id": "openssl 0.10.42",
+              "id": "openssl 0.10.43",
               "target": "build_script_build"
             },
             {
-              "id": "openssl-sys 0.9.77",
+              "id": "openssl-sys 0.9.78",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -14141,7 +14066,7 @@
           ],
           "selects": {}
         },
-        "version": "0.10.42"
+        "version": "0.10.43"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -14150,7 +14075,7 @@
         "deps": {
           "common": [
             {
-              "id": "openssl-sys 0.9.77",
+              "id": "openssl-sys 0.9.78",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -14199,7 +14124,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -14243,13 +14168,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "openssl-sys 0.9.77": {
+    "openssl-sys 0.9.78": {
       "name": "openssl-sys",
-      "version": "0.9.77",
+      "version": "0.9.78",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/openssl-sys/0.9.77/download",
-          "sha256": "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+          "url": "https://crates.io/api/v1/crates/openssl-sys/0.9.78/download",
+          "sha256": "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
         }
       },
       "targets": [
@@ -14290,14 +14215,14 @@
               "target": "libc"
             },
             {
-              "id": "openssl-sys 0.9.77",
+              "id": "openssl-sys 0.9.78",
               "target": "build_script_main"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.9.77"
+        "version": "0.9.78"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -14535,7 +14460,7 @@
               "target": "lock_api"
             },
             {
-              "id": "parking_lot_core 0.9.4",
+              "id": "parking_lot_core 0.9.5",
               "target": "parking_lot_core"
             }
           ],
@@ -14546,13 +14471,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "parking_lot_core 0.9.4": {
+    "parking_lot_core 0.9.5": {
       "name": "parking_lot_core",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.4/download",
-          "sha256": "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.5/download",
+          "sha256": "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
         }
       },
       "targets": [
@@ -14593,7 +14518,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "parking_lot_core 0.9.4",
+              "id": "parking_lot_core 0.9.5",
               "target": "build_script_build"
             },
             {
@@ -14623,7 +14548,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.9.4"
+        "version": "0.9.5"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -15055,13 +14980,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "pest 2.4.1": {
+    "pest 2.5.0": {
       "name": "pest",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest/2.4.1/download",
-          "sha256": "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+          "url": "https://crates.io/api/v1/crates/pest/2.5.0/download",
+          "sha256": "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
         }
       },
       "targets": [
@@ -15102,17 +15027,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.4.1"
+        "version": "2.5.0"
       },
       "license": "MIT/Apache-2.0"
     },
-    "pest_derive 2.4.1": {
+    "pest_derive 2.5.0": {
       "name": "pest_derive",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest_derive/2.4.1/download",
-          "sha256": "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
+          "url": "https://crates.io/api/v1/crates/pest_derive/2.5.0/download",
+          "sha256": "423c2ba011d6e27b02b482a3707c773d19aec65cc024637aec44e19652e66f63"
         }
       },
       "targets": [
@@ -15141,28 +15066,28 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.4.1",
+              "id": "pest 2.5.0",
               "target": "pest"
             },
             {
-              "id": "pest_generator 2.4.1",
+              "id": "pest_generator 2.5.0",
               "target": "pest_generator"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.4.1"
+        "version": "2.5.0"
       },
       "license": "MIT/Apache-2.0"
     },
-    "pest_generator 2.4.1": {
+    "pest_generator 2.5.0": {
       "name": "pest_generator",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest_generator/2.4.1/download",
-          "sha256": "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+          "url": "https://crates.io/api/v1/crates/pest_generator/2.5.0/download",
+          "sha256": "3e64e6c2c85031c02fdbd9e5c72845445ca0a724d419aa0bc068ac620c9935c1"
         }
       },
       "targets": [
@@ -15190,11 +15115,11 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.4.1",
+              "id": "pest 2.5.0",
               "target": "pest"
             },
             {
-              "id": "pest_meta 2.4.1",
+              "id": "pest_meta 2.5.0",
               "target": "pest_meta"
             },
             {
@@ -15206,24 +15131,24 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.4.1"
+        "version": "2.5.0"
       },
       "license": "MIT/Apache-2.0"
     },
-    "pest_meta 2.4.1": {
+    "pest_meta 2.5.0": {
       "name": "pest_meta",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest_meta/2.4.1/download",
-          "sha256": "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+          "url": "https://crates.io/api/v1/crates/pest_meta/2.5.0/download",
+          "sha256": "57959b91f0a133f89a68be874a5c88ed689c19cd729ecdb5d762ebf16c64d662"
         }
       },
       "targets": [
@@ -15252,14 +15177,14 @@
               "target": "once_cell"
             },
             {
-              "id": "pest 2.4.1",
+              "id": "pest 2.5.0",
               "target": "pest"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.4.1"
+        "version": "2.5.0"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -15344,7 +15269,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -15661,13 +15586,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "polling 2.4.0": {
+    "polling 2.5.1": {
       "name": "polling",
-      "version": "2.4.0",
+      "version": "2.5.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/polling/2.4.0/download",
-          "sha256": "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
+          "url": "https://crates.io/api/v1/crates/polling/2.5.1/download",
+          "sha256": "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
         }
       },
       "targets": [
@@ -15716,7 +15641,7 @@
               "target": "log"
             },
             {
-              "id": "polling 2.4.0",
+              "id": "polling 2.5.1",
               "target": "build_script_build"
             }
           ],
@@ -15733,14 +15658,14 @@
                 "target": "wepoll_ffi"
               },
               {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
+                "id": "windows-sys 0.42.0",
+                "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "2.4.0"
+        "version": "2.5.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -15855,7 +15780,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -16232,7 +16157,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -17086,7 +17011,7 @@
               "target": "http"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -17396,7 +17321,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -18224,13 +18149,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde 1.0.147": {
+    "serde 1.0.148": {
       "name": "serde",
-      "version": "1.0.147",
+      "version": "1.0.148",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.147/download",
-          "sha256": "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.148/download",
+          "sha256": "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
         }
       },
       "targets": [
@@ -18274,7 +18199,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "build_script_build"
             }
           ],
@@ -18284,13 +18209,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.147",
+              "id": "serde_derive 1.0.148",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.147"
+        "version": "1.0.148"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -18333,7 +18258,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -18344,13 +18269,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_derive 1.0.147": {
+    "serde_derive 1.0.148": {
       "name": "serde_derive",
-      "version": "1.0.147",
+      "version": "1.0.148",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.147/download",
-          "sha256": "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.148/download",
+          "sha256": "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
         }
       },
       "targets": [
@@ -18398,18 +18323,18 @@
               "target": "quote"
             },
             {
-              "id": "serde_derive 1.0.147",
+              "id": "serde_derive 1.0.148",
               "target": "build_script_build"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.147"
+        "version": "1.0.148"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -18474,7 +18399,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -18533,7 +18458,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -18579,11 +18504,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -18637,7 +18562,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -19340,13 +19265,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "smol 1.2.5": {
+    "smol 1.3.0": {
       "name": "smol",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/smol/1.2.5/download",
-          "sha256": "85cf3b5351f3e783c1d79ab5fc604eeed8b8ae9abd36b166e8b87a089efd85e4"
+          "url": "https://crates.io/api/v1/crates/smol/1.3.0/download",
+          "sha256": "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
         }
       },
       "targets": [
@@ -19371,7 +19296,7 @@
         "deps": {
           "common": [
             {
-              "id": "async-channel 1.7.1",
+              "id": "async-channel 1.8.0",
               "target": "async_channel"
             },
             {
@@ -19383,7 +19308,7 @@
               "target": "async_fs"
             },
             {
-              "id": "async-io 1.10.0",
+              "id": "async-io 1.12.0",
               "target": "async_io"
             },
             {
@@ -19395,26 +19320,22 @@
               "target": "async_net"
             },
             {
-              "id": "async-process 1.5.0",
+              "id": "async-process 1.6.0",
               "target": "async_process"
             },
             {
-              "id": "blocking 1.2.0",
+              "id": "blocking 1.3.0",
               "target": "blocking"
             },
             {
               "id": "futures-lite 1.12.0",
               "target": "futures_lite"
-            },
-            {
-              "id": "once_cell 1.16.0",
-              "target": "once_cell"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.2.5"
+        "version": "1.3.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -19788,7 +19709,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -19927,13 +19848,13 @@
       },
       "license": "BSD-3-Clause"
     },
-    "syn 1.0.103": {
+    "syn 1.0.104": {
       "name": "syn",
-      "version": "1.0.103",
+      "version": "1.0.104",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.103/download",
-          "sha256": "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.104/download",
+          "sha256": "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
         }
       },
       "targets": [
@@ -19991,7 +19912,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "build_script_build"
             },
             {
@@ -20002,7 +19923,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.103"
+        "version": "1.0.104"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -20054,7 +19975,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             },
             {
@@ -20069,13 +19990,13 @@
       },
       "license": "MIT"
     },
-    "sysinfo 0.26.7": {
+    "sysinfo 0.26.8": {
       "name": "sysinfo",
-      "version": "0.26.7",
+      "version": "0.26.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sysinfo/0.26.7/download",
-          "sha256": "c375d5fd899e32847b8566e10598d6e9f1d9b55ec6de3cdf9e7da4bdc51371bc"
+          "url": "https://crates.io/api/v1/crates/sysinfo/0.26.8/download",
+          "sha256": "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
         }
       },
       "targets": [
@@ -20136,7 +20057,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.26.7"
+        "version": "0.26.8"
       },
       "license": "MIT"
     },
@@ -20393,7 +20314,7 @@
               "target": "prost_types"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -20439,7 +20360,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.58",
+              "id": "async-trait 0.1.59",
               "target": "async_trait"
             },
             {
@@ -20561,7 +20482,7 @@
               "target": "flex_error"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -20639,7 +20560,7 @@
               "target": "prost_types"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -20766,7 +20687,7 @@
               "target": "pin_project"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -20832,7 +20753,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.58",
+              "id": "async-trait 0.1.59",
               "target": "async_trait"
             }
           ],
@@ -21118,7 +21039,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -21214,7 +21135,7 @@
               "target": "itoa"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             },
             {
@@ -21583,7 +21504,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tokio-macros 1.8.0",
+              "id": "tokio-macros 1.8.2",
               "target": "tokio_macros"
             }
           ],
@@ -21607,13 +21528,13 @@
       },
       "license": "MIT"
     },
-    "tokio-macros 1.8.0": {
+    "tokio-macros 1.8.2": {
       "name": "tokio-macros",
-      "version": "1.8.0",
+      "version": "1.8.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-macros/1.8.0/download",
-          "sha256": "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+          "url": "https://crates.io/api/v1/crates/tokio-macros/1.8.2/download",
+          "sha256": "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
         }
       },
       "targets": [
@@ -21646,14 +21567,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.8.0"
+        "version": "1.8.2"
       },
       "license": "MIT"
     },
@@ -21854,7 +21775,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -22002,7 +21923,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -22332,7 +22253,7 @@
               "target": "once_cell"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.148",
               "target": "serde"
             }
           ],
@@ -22391,7 +22312,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             }
           ],
@@ -22943,13 +22864,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "vergen 7.4.2": {
+    "vergen 7.4.3": {
       "name": "vergen",
-      "version": "7.4.2",
+      "version": "7.4.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/vergen/7.4.2/download",
-          "sha256": "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+          "url": "https://crates.io/api/v1/crates/vergen/7.4.3/download",
+          "sha256": "447f9238a4553957277b3ee09d80babeae0811f1b3baefb093de1c0448437a37"
         }
       },
       "targets": [
@@ -23018,7 +22939,7 @@
               "target": "rustc_version"
             },
             {
-              "id": "sysinfo 0.26.7",
+              "id": "sysinfo 0.26.8",
               "target": "sysinfo"
             },
             {
@@ -23030,7 +22951,7 @@
               "target": "time"
             },
             {
-              "id": "vergen 7.4.2",
+              "id": "vergen 7.4.3",
               "target": "build_script_build"
             }
           ],
@@ -23046,7 +22967,7 @@
           ],
           "selects": {}
         },
-        "version": "7.4.2"
+        "version": "7.4.3"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -23527,7 +23448,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             },
             {
@@ -23690,7 +23611,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             },
             {
@@ -24155,7 +24076,6 @@
           "winioctl",
           "winnt",
           "winreg",
-          "winsock2",
           "winuser",
           "ws2ipdef",
           "ws2tcpip",
@@ -24506,6 +24426,7 @@
           "Win32_System_LibraryLoader",
           "Win32_System_Pipes",
           "Win32_System_SystemServices",
+          "Win32_System_Threading",
           "Win32_System_WindowsProgramming",
           "default"
         ],
@@ -25447,7 +25368,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.104",
               "target": "syn"
             },
             {

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9522d71094ba5144046e9a2a44c3a6d0be73e4695e11b067fdd44443ed91f1df",
+  "checksum": "67ac4227c8f0b31d984f69751735510e784219a59fd6b70a7cd742d14e4aaaec",
   "crates": {
     "aes 0.7.5": {
       "name": "aes",
@@ -58,13 +58,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "aho-corasick 0.7.19": {
+    "aho-corasick 0.7.20": {
       "name": "aho-corasick",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/aho-corasick/0.7.19/download",
-          "sha256": "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+          "url": "https://crates.io/api/v1/crates/aho-corasick/0.7.20/download",
+          "sha256": "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
         }
       },
       "targets": [
@@ -100,9 +100,9 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.7.19"
+        "version": "0.7.20"
       },
-      "license": "Unlicense/MIT"
+      "license": "Unlicense OR MIT"
     },
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -1996,7 +1996,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.76",
+              "id": "cc 1.0.77",
               "target": "cc"
             }
           ],
@@ -2344,13 +2344,13 @@
       },
       "license": "Unlicense OR MIT"
     },
-    "bytes 1.2.1": {
+    "bytes 1.3.0": {
       "name": "bytes",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytes/1.2.1/download",
-          "sha256": "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+          "url": "https://crates.io/api/v1/crates/bytes/1.3.0/download",
+          "sha256": "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
         }
       },
       "targets": [
@@ -2387,7 +2387,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.2.1"
+        "version": "1.3.0"
       },
       "license": "MIT"
     },
@@ -2457,7 +2457,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.76",
+              "id": "cc 1.0.77",
               "target": "cc"
             },
             {
@@ -2504,13 +2504,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "cc 1.0.76": {
+    "cc 1.0.77": {
       "name": "cc",
-      "version": "1.0.76",
+      "version": "1.0.77",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cc/1.0.76/download",
-          "sha256": "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+          "url": "https://crates.io/api/v1/crates/cc/1.0.77/download",
+          "sha256": "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
         }
       },
       "targets": [
@@ -2558,7 +2558,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.76"
+        "version": "1.0.77"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3178,7 +3178,7 @@
               "target": "clap_lex"
             },
             {
-              "id": "indexmap 1.9.1",
+              "id": "indexmap 1.9.2",
               "target": "indexmap"
             },
             {
@@ -3306,7 +3306,7 @@
         "deps": {
           "common": [
             {
-              "id": "os_str_bytes 6.4.0",
+              "id": "os_str_bytes 6.4.1",
               "target": "os_str_bytes"
             }
           ],
@@ -3447,7 +3447,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-utils 0.8.12",
+              "id": "crossbeam-utils 0.8.14",
               "target": "crossbeam_utils"
             }
           ],
@@ -3872,13 +3872,13 @@
       },
       "license": "MIT"
     },
-    "crossbeam-utils 0.8.12": {
+    "crossbeam-utils 0.8.14": {
       "name": "crossbeam-utils",
-      "version": "0.8.12",
+      "version": "0.8.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.12/download",
-          "sha256": "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.14/download",
+          "sha256": "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
         }
       },
       "targets": [
@@ -3919,14 +3919,14 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-utils 0.8.12",
+              "id": "crossbeam-utils 0.8.14",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.12"
+        "version": "0.8.14"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5427,13 +5427,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "digest 0.10.5": {
+    "digest 0.10.6": {
       "name": "digest",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/digest/0.10.5/download",
-          "sha256": "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+          "url": "https://crates.io/api/v1/crates/digest/0.10.6/download",
+          "sha256": "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
         }
       },
       "targets": [
@@ -5482,7 +5482,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.5"
+        "version": "0.10.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7953,7 +7953,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -7977,7 +7977,7 @@
               "target": "http"
             },
             {
-              "id": "indexmap 1.9.1",
+              "id": "indexmap 1.9.2",
               "target": "indexmap"
             },
             {
@@ -7985,7 +7985,7 @@
               "target": "slab"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -8156,7 +8156,7 @@
               "target": "bitflags"
             },
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -8435,7 +8435,7 @@
         "deps": {
           "common": [
             {
-              "id": "digest 0.10.5",
+              "id": "digest 0.10.6",
               "target": "digest"
             }
           ],
@@ -8477,7 +8477,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -8527,7 +8527,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -8612,7 +8612,7 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -8801,7 +8801,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -8849,7 +8849,7 @@
               "target": "socket2"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -8911,7 +8911,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -8939,7 +8939,7 @@
               "target": "rustls_native_certs"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -9025,7 +9025,7 @@
               "target": "rustls_native_certs"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -9079,7 +9079,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -9091,7 +9091,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -9227,7 +9227,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             }
           ],
@@ -9283,13 +9283,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "indexmap 1.9.1": {
+    "indexmap 1.9.2": {
       "name": "indexmap",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/indexmap/1.9.1/download",
-          "sha256": "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+          "url": "https://crates.io/api/v1/crates/indexmap/1.9.2/download",
+          "sha256": "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
         }
       },
       "targets": [
@@ -9333,14 +9333,14 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 1.9.1",
+              "id": "indexmap 1.9.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.9.1"
+        "version": "1.9.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9911,7 +9911,7 @@
               "target": "syslog_tracing"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -10102,7 +10102,7 @@
               "target": "syslog_tracing"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -10112,6 +10112,63 @@
             {
               "id": "tracing-subscriber 0.3.16",
               "target": "tracing_subscriber"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "Apache-2.0"
+    },
+    "ledger-db 0.1.0": {
+      "name": "ledger-db",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Binary": {
+            "crate_name": "ledger-db",
+            "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": null,
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "clap 3.2.23",
+              "target": "clap"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
+              "id": "merk 1.0.0",
+              "target": "merk"
+            },
+            {
+              "id": "minicbor 0.18.0",
+              "target": "minicbor"
             }
           ],
           "selects": {}
@@ -10251,7 +10308,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.76",
+              "id": "cc 1.0.77",
               "target": "cc"
             },
             {
@@ -10394,7 +10451,7 @@
               "target": "bindgen"
             },
             {
-              "id": "cc 1.0.76",
+              "id": "cc 1.0.77",
               "target": "cc"
             },
             {
@@ -10484,7 +10541,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.76",
+              "id": "cc 1.0.77",
               "target": "cc"
             },
             {
@@ -10867,7 +10924,7 @@
               "target": "num_integer"
             },
             {
-              "id": "reqwest 0.11.12",
+              "id": "reqwest 0.11.13",
               "target": "reqwest"
             },
             {
@@ -10903,7 +10960,7 @@
               "target": "tendermint_rpc"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -10950,9 +11007,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-client"
         }
@@ -11082,7 +11139,7 @@
               "target": "regex"
             },
             {
-              "id": "reqwest 0.11.12",
+              "id": "reqwest 0.11.13",
               "target": "reqwest"
             },
             {
@@ -11106,7 +11163,7 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -11143,9 +11200,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-client-macros"
         }
@@ -11196,9 +11253,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-error"
         }
@@ -11262,9 +11319,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-identity"
         }
@@ -11363,9 +11420,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-identity-dsa"
         }
@@ -11497,9 +11554,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-identity-hsm"
         }
@@ -11590,9 +11647,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-identity-webauthn"
         }
@@ -11655,7 +11712,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             },
             {
@@ -11796,7 +11853,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             },
             {
@@ -11820,7 +11877,7 @@
               "target": "syslog_tracing"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -12029,7 +12086,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             },
             {
@@ -12053,7 +12110,7 @@
               "target": "syslog_tracing"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -12129,9 +12186,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-macros"
         }
@@ -12194,9 +12251,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-migration"
         }
@@ -12223,6 +12280,10 @@
         "deps": {
           "common": [
             {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
               "id": "minicbor 0.18.0",
               "target": "minicbor"
             },
@@ -12231,7 +12292,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             },
             {
@@ -12255,9 +12316,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-modules"
         }
@@ -12353,9 +12414,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-protocol"
         }
@@ -12426,7 +12487,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             },
             {
@@ -12467,9 +12528,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-server"
         }
@@ -12607,7 +12668,7 @@
               "target": "regex"
             },
             {
-              "id": "reqwest 0.11.12",
+              "id": "reqwest 0.11.13",
               "target": "reqwest"
             },
             {
@@ -12615,7 +12676,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             },
             {
@@ -12643,7 +12704,7 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -12684,9 +12745,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/hansl/many-rs.git",
           "commitish": {
-            "Rev": "539f8aa33c8c8f10872373bf5665d20fafb8a7a6"
+            "Branch": "memo-refactor"
           },
           "strip_prefix": "src/many-types"
         }
@@ -14249,7 +14310,7 @@
               "target": "autocfg"
             },
             {
-              "id": "cc 1.0.76",
+              "id": "cc 1.0.77",
               "target": "cc"
             },
             {
@@ -14270,13 +14331,13 @@
       },
       "license": "MIT"
     },
-    "os_str_bytes 6.4.0": {
+    "os_str_bytes 6.4.1": {
       "name": "os_str_bytes",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.4.0/download",
-          "sha256": "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.4.1/download",
+          "sha256": "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
         }
       },
       "targets": [
@@ -14302,7 +14363,7 @@
           "raw_os_str"
         ],
         "edition": "2021",
-        "version": "6.4.0"
+        "version": "6.4.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -14635,7 +14696,7 @@
         "deps": {
           "common": [
             {
-              "id": "digest 0.10.5",
+              "id": "digest 0.10.6",
               "target": "digest"
             }
           ],
@@ -16104,7 +16165,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             }
           ],
@@ -16213,7 +16274,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -16866,7 +16927,7 @@
         "deps": {
           "common": [
             {
-              "id": "aho-corasick 0.7.19",
+              "id": "aho-corasick 0.7.20",
               "target": "aho_corasick"
             },
             {
@@ -16973,13 +17034,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "reqwest 0.11.12": {
+    "reqwest 0.11.13": {
       "name": "reqwest",
-      "version": "0.11.12",
+      "version": "0.11.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/reqwest/0.11.12/download",
-          "sha256": "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+          "url": "https://crates.io/api/v1/crates/reqwest/0.11.13/download",
+          "sha256": "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
         }
       },
       "targets": [
@@ -17017,7 +17078,7 @@
               "target": "base64"
             },
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -17101,7 +17162,7 @@
                 "target": "pin_project_lite"
               },
               {
-                "id": "tokio 1.21.2",
+                "id": "tokio 1.22.0",
                 "target": "tokio"
               },
               {
@@ -17115,7 +17176,7 @@
                 "target": "js_sys"
               },
               {
-                "id": "serde_json 1.0.87",
+                "id": "serde_json 1.0.89",
                 "target": "serde_json"
               },
               {
@@ -17140,7 +17201,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.11.12"
+        "version": "0.11.13"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -17248,7 +17309,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.76",
+              "id": "cc 1.0.77",
               "target": "cc"
             }
           ],
@@ -17339,7 +17400,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             }
           ],
@@ -18357,13 +18418,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_json 1.0.87": {
+    "serde_json 1.0.89": {
       "name": "serde_json",
-      "version": "1.0.87",
+      "version": "1.0.89",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_json/1.0.87/download",
-          "sha256": "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+          "url": "https://crates.io/api/v1/crates/serde_json/1.0.89/download",
+          "sha256": "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
         }
       },
       "targets": [
@@ -18417,14 +18478,14 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.87"
+        "version": "1.0.89"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -18626,7 +18687,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "digest 0.10.5",
+              "id": "digest 0.10.6",
               "target": "digest"
             }
           ],
@@ -18683,7 +18744,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "digest 0.10.5",
+              "id": "digest 0.10.6",
               "target": "digest"
             }
           ],
@@ -18800,7 +18861,7 @@
         "deps": {
           "common": [
             {
-              "id": "digest 0.10.5",
+              "id": "digest 0.10.6",
               "target": "digest"
             },
             {
@@ -20296,7 +20357,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -20340,7 +20401,7 @@
               "target": "serde_bytes"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             },
             {
@@ -20438,7 +20499,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -20504,7 +20565,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             },
             {
@@ -20558,7 +20619,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -20665,7 +20726,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -20713,7 +20774,7 @@
               "target": "serde_bytes"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.89",
               "target": "serde_json"
             },
             {
@@ -20745,7 +20806,7 @@
               "target": "time"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -21397,13 +21458,13 @@
       },
       "license": "MIT OR Apache-2.0 OR Zlib"
     },
-    "tokio 1.21.2": {
+    "tokio 1.22.0": {
       "name": "tokio",
-      "version": "1.21.2",
+      "version": "1.22.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio/1.21.2/download",
-          "sha256": "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+          "url": "https://crates.io/api/v1/crates/tokio/1.22.0/download",
+          "sha256": "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
         }
       },
       "targets": [
@@ -21465,7 +21526,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -21489,7 +21550,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "build_script_build"
             }
           ],
@@ -21528,7 +21589,7 @@
           ],
           "selects": {}
         },
-        "version": "1.21.2"
+        "version": "1.22.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -21631,7 +21692,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             }
           ],
@@ -21677,7 +21738,7 @@
               "target": "rustls"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -21728,7 +21789,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -21744,7 +21805,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.21.2",
+              "id": "tokio 1.22.0",
               "target": "tokio"
             },
             {
@@ -23073,8 +23134,8 @@
         },
         {
           "Binary": {
-            "crate_name": "reader",
-            "crate_root": "src/bin/reader.rs",
+            "crate_name": "exit",
+            "crate_root": "src/bin/exit.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -23097,8 +23158,8 @@
         },
         {
           "Binary": {
-            "crate_name": "exit",
-            "crate_root": "src/bin/exit.rs",
+            "crate_name": "reader",
+            "crate_root": "src/bin/reader.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -23941,7 +24002,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.76",
+              "id": "cc 1.0.77",
               "target": "cc"
             }
           ],
@@ -25405,7 +25466,7 @@
   "binary_crates": [
     "bindgen 0.59.2",
     "bindgen 0.60.1",
-    "cc 1.0.76",
+    "cc 1.0.77",
     "clap 3.2.23",
     "minicbor 0.18.0",
     "peg-macros 0.7.0",
@@ -25419,6 +25480,7 @@
     "idstore-export 0.1.0": "src/idstore-export",
     "kvstore 0.1.0": "src/kvstore",
     "ledger 0.1.0": "src/ledger",
+    "ledger-db 0.1.0": "src/ledger-db",
     "many-abci 0.1.0": "src/many-abci",
     "many-kvstore 0.1.0": "src/many-kvstore",
     "many-ledger 0.1.0": "src/many-ledger"

--- a/docker/e2e/Cargo.nix
+++ b/docker/e2e/Cargo.nix
@@ -8,6 +8,7 @@ args@{
     "many-kvstore/default"
     "idstore-export/default"
     "ledger/default"
+    "ledger-db/default"
     "kvstore/default"
     "many-abci/default"
     "many-ledger/default"
@@ -29,7 +30,7 @@ args@{
   ignoreLockHash,
 }:
 let
-  nixifiedLockHash = "93cf2e91323f4c8ec6d530bbd3d3c170457f654f9c4804296f72f402db552c2f";
+  nixifiedLockHash = "0ff2aef27bb7354822f68b5566188e2fc21e94c5b62f2f31f429e031764b9cf6";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
   currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
   lockHashIgnored = if ignoreLockHash
@@ -57,6 +58,7 @@ in
     many-kvstore = rustPackages.unknown.many-kvstore."0.1.0";
     idstore-export = rustPackages.unknown.idstore-export."0.1.0";
     ledger = rustPackages.unknown.ledger."0.1.0";
+    ledger-db = rustPackages.unknown.ledger-db."0.1.0";
     kvstore = rustPackages.unknown.kvstore."0.1.0";
     many-abci = rustPackages.unknown.many-abci."0.1.0";
     many-ledger = rustPackages.unknown.many-ledger."0.1.0";
@@ -74,11 +76,11 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.19" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.20" = overridableMkRustCrate (profileName: rec {
     name = "aho-corasick";
-    version = "0.7.19";
+    version = "0.7.20";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"; };
+    src = fetchCratesIo { inherit name version; sha256 = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"; };
     features = builtins.concatLists [
       [ "default" ]
       [ "std" ]
@@ -144,7 +146,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "cfffb35195feaeffb071af0f7a643405667813dd8629c27cb0c310fb76654ab1"; };
     dependencies = {
-      chrono = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.22" { inherit profileName; }).out;
+      chrono = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.23" { inherit profileName; }).out;
     };
   });
   
@@ -162,7 +164,7 @@ in
     ];
     dependencies = {
       asn1_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".asn1_derive."0.10.0" { profileName = "__noProfile"; }).out;
-      chrono = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.22" { inherit profileName; }).out;
+      chrono = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.23" { inherit profileName; }).out;
     };
   });
   
@@ -172,7 +174,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "4a0959d3f3489cab2f24b15d637451fe3e8a6b3bfe6bd5ebbc8080fa931a77d3"; };
     dependencies = {
-      chrono = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.22" { inherit profileName; }).out;
+      chrono = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.23" { inherit profileName; }).out;
     };
   });
   
@@ -518,7 +520,7 @@ in
       digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.9.0" { inherit profileName; }).out;
     };
     buildDependencies = {
-      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.76" { profileName = "__noProfile"; }).out;
+      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.77" { profileName = "__noProfile"; }).out;
     };
   });
   
@@ -608,11 +610,11 @@ in
     ];
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" = overridableMkRustCrate (profileName: rec {
     name = "bytes";
-    version = "1.2.1";
+    version = "1.3.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"; };
+    src = fetchCratesIo { inherit name version; sha256 = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"; };
     features = builtins.concatLists [
       [ "default" ]
       [ "serde" ]
@@ -635,7 +637,7 @@ in
       libc = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.137" { inherit profileName; }).out;
     };
     buildDependencies = {
-      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.76" { profileName = "__noProfile"; }).out;
+      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.77" { profileName = "__noProfile"; }).out;
       pkg_config = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.26" { profileName = "__noProfile"; }).out;
     };
   });
@@ -647,11 +649,11 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"; };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".cc."1.0.76" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".cc."1.0.77" = overridableMkRustCrate (profileName: rec {
     name = "cc";
-    version = "1.0.76";
+    version = "1.0.77";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"; };
+    src = fetchCratesIo { inherit name version; sha256 = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"; };
     features = builtins.concatLists [
       [ "jobserver" ]
       [ "parallel" ]
@@ -685,11 +687,11 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"; };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.22" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".chrono."0.4.23" = overridableMkRustCrate (profileName: rec {
     name = "chrono";
-    version = "0.4.22";
+    version = "0.4.23";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"; };
+    src = fetchCratesIo { inherit name version; sha256 = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"; };
     features = builtins.concatLists [
       [ "alloc" ]
     ];
@@ -840,7 +842,7 @@ in
       bitflags = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bitflags."1.3.2" { inherit profileName; }).out;
       clap_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".clap_derive."3.2.18" { profileName = "__noProfile"; }).out;
       clap_lex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap_lex."0.2.4" { inherit profileName; }).out;
-      indexmap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indexmap."1.9.1" { inherit profileName; }).out;
+      indexmap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indexmap."1.9.2" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.16.0" { inherit profileName; }).out;
       strsim = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".strsim."0.10.0" { inherit profileName; }).out;
       termcolor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".termcolor."1.1.3" { inherit profileName; }).out;
@@ -871,7 +873,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"; };
     dependencies = {
-      os_str_bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".os_str_bytes."6.3.1" { inherit profileName; }).out;
+      os_str_bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".os_str_bytes."6.4.1" { inherit profileName; }).out;
     };
   });
   
@@ -907,7 +909,7 @@ in
       [ "std" ]
     ];
     dependencies = {
-      crossbeam_utils = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.8.12" { inherit profileName; }).out;
+      crossbeam_utils = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.8.14" { inherit profileName; }).out;
     };
   });
   
@@ -1000,11 +1002,11 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.8.12" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.8.14" = overridableMkRustCrate (profileName: rec {
     name = "crossbeam-utils";
-    version = "0.8.12";
+    version = "0.8.14";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"; };
+    src = fetchCratesIo { inherit name version; sha256 = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"; };
     dependencies = {
       cfg_if = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."1.0.0" { inherit profileName; }).out;
     };
@@ -1431,11 +1433,11 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".digest."0.10.5" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".digest."0.10.6" = overridableMkRustCrate (profileName: rec {
     name = "digest";
-    version = "0.10.5";
+    version = "0.10.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"; };
+    src = fetchCratesIo { inherit name version; sha256 = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"; };
     features = builtins.concatLists [
       [ "alloc" ]
       [ "block-buffer" ]
@@ -2077,15 +2079,15 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"; };
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       fnv = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fnv."1.0.7" { inherit profileName; }).out;
       futures_core = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-core."0.3.25" { inherit profileName; }).out;
       futures_sink = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-sink."0.3.25" { inherit profileName; }).out;
       futures_util = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-util."0.3.25" { inherit profileName; }).out;
       http = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".http."0.2.8" { inherit profileName; }).out;
-      indexmap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indexmap."1.9.1" { inherit profileName; }).out;
+      indexmap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indexmap."1.9.2" { inherit profileName; }).out;
       slab = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".slab."0.4.7" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tokio_util = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio-util."0.7.4" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
     };
@@ -2126,7 +2128,7 @@ in
     dependencies = {
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.1" { inherit profileName; }).out;
       bitflags = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bitflags."1.3.2" { inherit profileName; }).out;
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       headers_core = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".headers-core."0.2.0" { inherit profileName; }).out;
       http = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".http."0.2.8" { inherit profileName; }).out;
       httpdate = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".httpdate."1.0.2" { inherit profileName; }).out;
@@ -2201,7 +2203,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"; };
     dependencies = {
-      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.5" { inherit profileName; }).out;
+      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.6" { inherit profileName; }).out;
     };
   });
   
@@ -2211,7 +2213,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"; };
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       fnv = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fnv."1.0.7" { inherit profileName; }).out;
       itoa = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itoa."1.0.4" { inherit profileName; }).out;
     };
@@ -2223,7 +2225,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"; };
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       http = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".http."0.2.8" { inherit profileName; }).out;
       pin_project_lite = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".pin-project-lite."0.2.9" { inherit profileName; }).out;
     };
@@ -2237,16 +2239,16 @@ in
     dependencies = {
       clap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.23" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/hansl/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       many_kvstore = (rustPackages."unknown".many-kvstore."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       new_mime_guess = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".new_mime_guess."4.0.1" { inherit profileName; }).out;
       syslog_tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syslog-tracing."0.1.0" { inherit profileName; }).out;
       tiny_http = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.11.0" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
       tracing_subscriber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.16" { inherit profileName; }).out;
     };
@@ -2293,7 +2295,7 @@ in
       [ "tcp" ]
     ];
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       futures_channel = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-channel."0.3.25" { inherit profileName; }).out;
       futures_core = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-core."0.3.25" { inherit profileName; }).out;
       futures_util = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-util."0.3.25" { inherit profileName; }).out;
@@ -2305,7 +2307,7 @@ in
       itoa = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itoa."1.0.4" { inherit profileName; }).out;
       pin_project_lite = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".pin-project-lite."0.2.9" { inherit profileName; }).out;
       socket2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".socket2."0.4.7" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tower_service = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tower-service."0.3.2" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
       want = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".want."0.3.0" { inherit profileName; }).out;
@@ -2326,14 +2328,14 @@ in
       [ "webpki" ]
     ];
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       futures = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures."0.3.25" { inherit profileName; }).out;
       headers = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".headers."0.3.8" { inherit profileName; }).out;
       http = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".http."0.2.8" { inherit profileName; }).out;
       hyper = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hyper."0.14.23" { inherit profileName; }).out;
       hyper_rustls = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hyper-rustls."0.22.1" { inherit profileName; }).out;
       rustls_native_certs = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustls-native-certs."0.5.0" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tokio_rustls = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio-rustls."0.22.0" { inherit profileName; }).out;
       tower_service = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tower-service."0.3.2" { inherit profileName; }).out;
       webpki = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".webpki."0.21.4" { inherit profileName; }).out;
@@ -2360,7 +2362,7 @@ in
       log = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.17" { inherit profileName; }).out;
       rustls = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustls."0.19.1" { inherit profileName; }).out;
       rustls_native_certs = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustls-native-certs."0.5.0" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tokio_rustls = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio-rustls."0.22.0" { inherit profileName; }).out;
       webpki = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".webpki."0.21.4" { inherit profileName; }).out;
       webpki_roots = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".webpki-roots."0.21.1" { inherit profileName; }).out;
@@ -2373,10 +2375,10 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"; };
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       hyper = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hyper."0.14.23" { inherit profileName; }).out;
       native_tls = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".native-tls."0.2.11" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tokio_native_tls = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio-native-tls."0.3.0" { inherit profileName; }).out;
     };
   });
@@ -2410,7 +2412,7 @@ in
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."1.0.0" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
       serde_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_derive."1.0.147" { profileName = "__noProfile"; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
     };
   });
   
@@ -2424,11 +2426,11 @@ in
     ];
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".indexmap."1.9.1" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".indexmap."1.9.2" = overridableMkRustCrate (profileName: rec {
     name = "indexmap";
-    version = "1.9.1";
+    version = "1.9.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"; };
+    src = fetchCratesIo { inherit name version; sha256 = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"; };
     features = builtins.concatLists [
       [ "std" ]
     ];
@@ -2548,11 +2550,14 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".keccak."0.1.2" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".keccak."0.1.3" = overridableMkRustCrate (profileName: rec {
     name = "keccak";
-    version = "0.1.2";
+    version = "0.1.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"; };
+    src = fetchCratesIo { inherit name version; sha256 = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"; };
+    dependencies = {
+      ${ if hostPlatform.parsed.cpu.name == "aarch64" then "cpufeatures" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cpufeatures."0.2.5" { inherit profileName; }).out;
+    };
   });
   
   "unknown".kvstore."0.1.0" = overridableMkRustCrate (profileName: rec {
@@ -2564,16 +2569,16 @@ in
       clap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.23" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
       indicatif = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indicatif."0.16.2" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/hansl/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       syslog_tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syslog-tracing."0.1.0" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
       tracing_subscriber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.16" { inherit profileName; }).out;
     };
@@ -2605,23 +2610,38 @@ in
       humantime = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".humantime."2.1.0" { inherit profileName; }).out;
       indicatif = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indicatif."0.16.2" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_identity_hsm = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-hsm."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/hansl/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity_hsm = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-hsm."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       regex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.7.0" { inherit profileName; }).out;
       ring = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".ring."0.16.20" { inherit profileName; }).out;
       rpassword = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rpassword."6.0.1" { inherit profileName; }).out;
       syslog_tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syslog-tracing."0.1.0" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
       tracing_subscriber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.16" { inherit profileName; }).out;
+    };
+  });
+  
+  "unknown".ledger-db."0.1.0" = overridableMkRustCrate (profileName: rec {
+    name = "ledger-db";
+    version = "0.1.0";
+    registry = "unknown";
+    src = fetchCrateLocal (workspaceSrc + "/src/ledger-db");
+    dependencies = {
+      clap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.23" { inherit profileName; }).out;
+      hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."1.0.0" { inherit profileName; }).out;
+      minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
     };
   });
   
@@ -2646,7 +2666,7 @@ in
       libz_sys = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.1.8" { inherit profileName; }).out;
     };
     buildDependencies = {
-      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.76" { profileName = "__noProfile"; }).out;
+      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.77" { profileName = "__noProfile"; }).out;
       pkg_config = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.26" { profileName = "__noProfile"; }).out;
     };
   });
@@ -2678,7 +2698,7 @@ in
     };
     buildDependencies = {
       bindgen = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".bindgen."0.60.1" { profileName = "__noProfile"; }).out;
-      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.76" { profileName = "__noProfile"; }).out;
+      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.77" { profileName = "__noProfile"; }).out;
       glob = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".glob."0.3.0" { profileName = "__noProfile"; }).out;
     };
   });
@@ -2696,7 +2716,7 @@ in
       libc = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.137" { inherit profileName; }).out;
     };
     buildDependencies = {
-      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.76" { profileName = "__noProfile"; }).out;
+      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.77" { profileName = "__noProfile"; }).out;
       pkg_config = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.26" { profileName = "__noProfile"; }).out;
       ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.15" { profileName = "__noProfile"; }).out;
     };
@@ -2770,18 +2790,18 @@ in
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       json5 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".json5."0.4.1" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_identity_webauthn = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/hansl/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity_webauthn = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/hansl/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_integer = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-integer."0.1.45" { inherit profileName; }).out;
-      reqwest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.12" { inherit profileName; }).out;
+      reqwest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.13" { inherit profileName; }).out;
       sha2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha2."0.10.6" { inherit profileName; }).out;
       signal_hook = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".signal-hook."0.3.14" { inherit profileName; }).out;
       smol = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".smol."1.2.5" { inherit profileName; }).out;
@@ -2790,7 +2810,7 @@ in
       tendermint_abci = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tendermint-abci."0.24.0-pre.2" { inherit profileName; }).out;
       tendermint_proto = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tendermint-proto."0.24.0-pre.2" { inherit profileName; }).out;
       tendermint_rpc = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tendermint-rpc."0.24.0-pre.2" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
       tracing_subscriber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.16" { inherit profileName; }).out;
     };
@@ -2799,15 +2819,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-client."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-client";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-client";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     features = builtins.concatLists [
       [ "default" ]
     ];
@@ -2825,13 +2846,13 @@ in
       fixed = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.20.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_client_macros = (buildRustPackages."git+https://github.com/liftedinit/many-rs.git".many-client-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client_macros = (buildRustPackages."git+https://github.com/hansl/many-rs.git".many-client-macros."0.1.0" { profileName = "__noProfile"; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/hansl/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
@@ -2840,26 +2861,27 @@ in
       pkcs8 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".pkcs8."0.8.0" { inherit profileName; }).out;
       rand = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand."0.8.5" { inherit profileName; }).out;
       regex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.7.0" { inherit profileName; }).out;
-      reqwest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.12" { inherit profileName; }).out;
+      reqwest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.13" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
       sha3 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha3."0.9.1" { inherit profileName; }).out;
       signature = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".signature."1.3.2" { inherit profileName; }).out;
       static_assertions = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".static_assertions."1.1.0" { inherit profileName; }).out;
       tiny_http = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.11.0" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-client-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-client-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-client-macros";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-client-macros";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     dependencies = {
       proc_macro2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.47" { inherit profileName; }).out;
       quote = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.21" { inherit profileName; }).out;
@@ -2867,15 +2889,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-error."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-error";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-error";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     features = builtins.concatLists [
       [ "default" ]
       [ "minicbor" ]
@@ -2888,15 +2911,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-identity";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     features = builtins.concatLists [
       [ "coset" ]
       [ "default" ]
@@ -2910,7 +2934,7 @@ in
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       crc_any = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".crc-any."2.4.3" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.16.0" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
@@ -2922,15 +2946,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity-dsa";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-identity-dsa";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     features = builtins.concatLists [
       [ "coset" ]
       [ "default" ]
@@ -2948,8 +2973,8 @@ in
       ed25519 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".ed25519."1.5.2" { inherit profileName; }).out;
       ed25519_dalek = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".ed25519-dalek."1.0.1" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.16.0" { inherit profileName; }).out;
       p256 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".p256."0.9.0" { inherit profileName; }).out;
@@ -2964,24 +2989,25 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-identity-hsm."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-identity-hsm."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity-hsm";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-identity-hsm";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     dependencies = {
       asn1 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".asn1."0.10.0" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       cryptoki = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cryptoki."0.3.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.16.0" { inherit profileName; }).out;
       p256 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".p256."0.9.0" { inherit profileName; }).out;
       sha2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha2."0.10.6" { inherit profileName; }).out;
@@ -2990,26 +3016,27 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-identity-webauthn."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-identity-webauthn."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity-webauthn";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-identity-webauthn";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     dependencies = {
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.1" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.16.0" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       sha2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha2."0.10.6" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
     };
@@ -3028,30 +3055,30 @@ in
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       json5 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".json5."0.4.1" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/hansl/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."1.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       sha3 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha3."0.10.6" { inherit profileName; }).out;
       signal_hook = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".signal-hook."0.3.14" { inherit profileName; }).out;
       simple_asn1 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".simple_asn1."0.6.2" { inherit profileName; }).out;
       strum = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".strum."0.24.1" { inherit profileName; }).out;
       syslog_tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syslog-tracing."0.1.0" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
       tracing_subscriber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.16" { inherit profileName; }).out;
     };
     devDependencies = {
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.16.0" { inherit profileName; }).out;
       tempfile = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tempfile."3.3.0" { inherit profileName; }).out;
     };
@@ -3080,37 +3107,37 @@ in
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       json5 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".json5."0.4.1" { inherit profileName; }).out;
       linkme = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".linkme."0.3.5" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_identity_webauthn = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
-      many_migration = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity_webauthn = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
+      many_migration = (rustPackages."git+https://github.com/hansl/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/hansl/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."1.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_traits = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-traits."0.2.15" { inherit profileName; }).out;
       rand = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand."0.8.5" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       sha3 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha3."0.9.1" { inherit profileName; }).out;
       signal_hook = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".signal-hook."0.3.14" { inherit profileName; }).out;
       simple_asn1 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".simple_asn1."0.6.2" { inherit profileName; }).out;
       strum = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".strum."0.24.1" { inherit profileName; }).out;
       syslog_tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syslog-tracing."0.1.0" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
       tracing_subscriber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.16" { inherit profileName; }).out;
       typenum = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".typenum."1.15.0" { inherit profileName; }).out;
       typetag = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".typetag."0.2.3" { inherit profileName; }).out;
     };
     devDependencies = {
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/hansl/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       many_ledger = (rustPackages."unknown".many-ledger."0.1.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.16.0" { inherit profileName; }).out;
       proptest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proptest."1.0.0" { inherit profileName; }).out;
@@ -3121,62 +3148,66 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-macros";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-macros";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     dependencies = {
       inflections = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".inflections."1.1.1" { inherit profileName; }).out;
       proc_macro2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.47" { inherit profileName; }).out;
       quote = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.21" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      serde_tokenstream = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_tokenstream."0.1.3" { inherit profileName; }).out;
+      serde_tokenstream = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_tokenstream."0.1.5" { inherit profileName; }).out;
       syn = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syn."1.0.103" { inherit profileName; }).out;
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-migration."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-migration."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-migration";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-migration";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     dependencies = {
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       strum = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".strum."0.24.1" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-modules";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-modules";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     dependencies = {
       async_trait = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".async-trait."0.1.58" { profileName = "__noProfile"; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       derive_builder = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".derive_builder."0.11.2" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_macros = (buildRustPackages."git+https://github.com/liftedinit/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_macros = (buildRustPackages."git+https://github.com/hansl/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       strum = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".strum."0.24.1" { inherit profileName; }).out;
@@ -3184,29 +3215,30 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-protocol";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-protocol";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     dependencies = {
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.1" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       derive_builder = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".derive_builder."0.10.2" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
       num_traits = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-traits."0.2.15" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       sha2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha2."0.10.6" { inherit profileName; }).out;
       signature = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".signature."1.3.2" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
@@ -3214,15 +3246,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-server."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-server";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-server";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     features = builtins.concatLists [
       [ "default" ]
     ];
@@ -3242,12 +3275,12 @@ in
       fixed = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.20.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_macros = (buildRustPackages."git+https://github.com/liftedinit/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_macros = (buildRustPackages."git+https://github.com/hansl/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
+      many_modules = (rustPackages."git+https://github.com/hansl/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/hansl/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/hansl/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
@@ -3257,9 +3290,9 @@ in
       pkcs8 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".pkcs8."0.8.0" { inherit profileName; }).out;
       rand = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand."0.8.5" { inherit profileName; }).out;
       regex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.7.0" { inherit profileName; }).out;
-      reqwest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.12" { inherit profileName; }).out;
+      reqwest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.13" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       sha2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha2."0.10.6" { inherit profileName; }).out;
       sha3 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha3."0.9.1" { inherit profileName; }).out;
       signature = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".signature."1.3.2" { inherit profileName; }).out;
@@ -3267,26 +3300,27 @@ in
       strum = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".strum."0.24.1" { inherit profileName; }).out;
       strum_macros = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".strum_macros."0.24.3" { profileName = "__noProfile"; }).out;
       tiny_http = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tiny_http."0.11.0" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/hansl/many-rs.git".many-types."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-types";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/hansl/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/hansl/many-rs.git;
       name = "many-types";
       version = "0.1.0";
-      rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6";};
+      rev = "817be3b05dfc61029dd1c22e1667238329b1d415";
+      ref = "memo-refactor";};
     dependencies = {
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       fixed = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.20.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/hansl/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/hansl/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
@@ -3641,17 +3675,17 @@ in
     };
     buildDependencies = {
       autocfg = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".autocfg."1.1.0" { profileName = "__noProfile"; }).out;
-      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.76" { profileName = "__noProfile"; }).out;
+      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.77" { profileName = "__noProfile"; }).out;
       pkg_config = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.26" { profileName = "__noProfile"; }).out;
       ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.15" { profileName = "__noProfile"; }).out;
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".os_str_bytes."6.3.1" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".os_str_bytes."6.4.1" = overridableMkRustCrate (profileName: rec {
     name = "os_str_bytes";
-    version = "6.3.1";
+    version = "6.4.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"; };
+    src = fetchCratesIo { inherit name version; sha256 = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"; };
     features = builtins.concatLists [
       [ "raw_os_str" ]
     ];
@@ -3747,7 +3781,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"; };
     dependencies = {
-      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.5" { inherit profileName; }).out;
+      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.6" { inherit profileName; }).out;
     };
   });
   
@@ -4123,7 +4157,7 @@ in
       [ "prost-derive" ]
     ];
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       prost_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".prost-derive."0.10.1" { profileName = "__noProfile"; }).out;
     };
   });
@@ -4148,7 +4182,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"; };
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       prost = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".prost."0.10.4" { inherit profileName; }).out;
     };
   });
@@ -4338,7 +4372,7 @@ in
       [ "unicode-segment" ]
     ];
     dependencies = {
-      aho_corasick = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.19" { inherit profileName; }).out;
+      aho_corasick = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.20" { inherit profileName; }).out;
       memchr = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.5.0" { inherit profileName; }).out;
       regex_syntax = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex-syntax."0.6.28" { inherit profileName; }).out;
     };
@@ -4372,11 +4406,11 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.12" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.13" = overridableMkRustCrate (profileName: rec {
     name = "reqwest";
-    version = "0.11.12";
+    version = "0.11.13";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"; };
+    src = fetchCratesIo { inherit name version; sha256 = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"; };
     features = builtins.concatLists [
       [ "__tls" ]
       [ "blocking" ]
@@ -4388,7 +4422,7 @@ in
     ];
     dependencies = {
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.1" { inherit profileName; }).out;
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       ${ if !(hostPlatform.parsed.cpu.name == "wasm32") then "encoding_rs" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".encoding_rs."0.8.31" { inherit profileName; }).out;
       ${ if !(hostPlatform.parsed.cpu.name == "wasm32") then "futures_core" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-core."0.3.25" { inherit profileName; }).out;
       ${ if !(hostPlatform.parsed.cpu.name == "wasm32") then "futures_util" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-util."0.3.25" { inherit profileName; }).out;
@@ -4406,9 +4440,9 @@ in
       ${ if !(hostPlatform.parsed.cpu.name == "wasm32") then "percent_encoding" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".percent-encoding."2.2.0" { inherit profileName; }).out;
       ${ if !(hostPlatform.parsed.cpu.name == "wasm32") then "pin_project_lite" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".pin-project-lite."0.2.9" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      ${ if hostPlatform.parsed.cpu.name == "wasm32" then "serde_json" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      ${ if hostPlatform.parsed.cpu.name == "wasm32" then "serde_json" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       serde_urlencoded = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_urlencoded."0.7.1" { inherit profileName; }).out;
-      ${ if !(hostPlatform.parsed.cpu.name == "wasm32") then "tokio" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      ${ if !(hostPlatform.parsed.cpu.name == "wasm32") then "tokio" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       ${ if !(hostPlatform.parsed.cpu.name == "wasm32") then "tokio_native_tls" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio-native-tls."0.3.0" { inherit profileName; }).out;
       tower_service = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tower-service."0.3.2" { inherit profileName; }).out;
       url = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.3.1" { inherit profileName; }).out;
@@ -4439,7 +4473,7 @@ in
       ${ if hostPlatform.parsed.kernel.name == "windows" then "winapi" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.9" { inherit profileName; }).out;
     };
     buildDependencies = {
-      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.76" { profileName = "__noProfile"; }).out;
+      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.77" { profileName = "__noProfile"; }).out;
     };
   });
   
@@ -4462,7 +4496,7 @@ in
     dependencies = {
       ${ if hostPlatform.isUnix then "libc" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.137" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       ${ if hostPlatform.isWindows then "winapi" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.9" { inherit profileName; }).out;
     };
   });
@@ -4709,11 +4743,11 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" = overridableMkRustCrate (profileName: rec {
     name = "serde_json";
-    version = "1.0.87";
+    version = "1.0.89";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"; };
+    src = fetchCratesIo { inherit name version; sha256 = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"; };
     features = builtins.concatLists [
       [ "alloc" ]
       [ "default" ]
@@ -4738,11 +4772,11 @@ in
     };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".serde_tokenstream."0.1.3" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".serde_tokenstream."0.1.5" = overridableMkRustCrate (profileName: rec {
     name = "serde_tokenstream";
-    version = "0.1.3";
+    version = "0.1.5";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "d6deb15c3a535e81438110111d90168d91721652f502abb147f31cde129f683d"; };
+    src = fetchCratesIo { inherit name version; sha256 = "2794f0ba0179a8ca422c30d9975d86faf8306be0164bfc3b0b1ca4f060ac639d"; };
     dependencies = {
       proc_macro2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.47" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
@@ -4775,7 +4809,7 @@ in
     dependencies = {
       cfg_if = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."1.0.0" { inherit profileName; }).out;
       ${ if hostPlatform.parsed.cpu.name == "aarch64" || hostPlatform.parsed.cpu.name == "i686" || hostPlatform.parsed.cpu.name == "x86_64" then "cpufeatures" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cpufeatures."0.2.5" { inherit profileName; }).out;
-      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.5" { inherit profileName; }).out;
+      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.6" { inherit profileName; }).out;
     };
   });
   
@@ -4808,7 +4842,7 @@ in
     dependencies = {
       cfg_if = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."1.0.0" { inherit profileName; }).out;
       ${ if hostPlatform.parsed.cpu.name == "aarch64" || hostPlatform.parsed.cpu.name == "x86_64" || hostPlatform.parsed.cpu.name == "i686" then "cpufeatures" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cpufeatures."0.2.5" { inherit profileName; }).out;
-      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.5" { inherit profileName; }).out;
+      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.6" { inherit profileName; }).out;
     };
   });
   
@@ -4824,7 +4858,7 @@ in
     dependencies = {
       block_buffer = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".block-buffer."0.9.0" { inherit profileName; }).out;
       digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.9.0" { inherit profileName; }).out;
-      keccak = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".keccak."0.1.2" { inherit profileName; }).out;
+      keccak = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".keccak."0.1.3" { inherit profileName; }).out;
       opaque_debug = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".opaque-debug."0.3.0" { inherit profileName; }).out;
     };
   });
@@ -4839,8 +4873,8 @@ in
       [ "std" ]
     ];
     dependencies = {
-      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.5" { inherit profileName; }).out;
-      keccak = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".keccak."0.1.2" { inherit profileName; }).out;
+      digest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".digest."0.10.6" { inherit profileName; }).out;
+      keccak = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".keccak."0.1.3" { inherit profileName; }).out;
     };
   });
   
@@ -5203,7 +5237,7 @@ in
     ];
     dependencies = {
       async_trait = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".async-trait."0.1.58" { profileName = "__noProfile"; }).out;
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       ed25519 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".ed25519."1.5.2" { inherit profileName; }).out;
       ed25519_consensus = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".ed25519-consensus."1.2.1" { inherit profileName; }).out;
       flex_error = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".flex-error."0.4.4" { inherit profileName; }).out;
@@ -5214,7 +5248,7 @@ in
       prost_types = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".prost-types."0.10.1" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
       serde_bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_bytes."0.11.7" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       serde_repr = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_repr."0.1.9" { profileName = "__noProfile"; }).out;
       sha2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha2."0.9.9" { inherit profileName; }).out;
       signature = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".signature."1.3.2" { inherit profileName; }).out;
@@ -5235,7 +5269,7 @@ in
       [ "default" ]
     ];
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       flex_error = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".flex-error."0.4.4" { inherit profileName; }).out;
       prost = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".prost."0.10.4" { inherit profileName; }).out;
       tendermint_proto = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tendermint-proto."0.24.0-pre.2" { inherit profileName; }).out;
@@ -5251,7 +5285,7 @@ in
     dependencies = {
       flex_error = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".flex-error."0.4.4" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       tendermint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tendermint."0.24.0-pre.2" { inherit profileName; }).out;
       toml = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".toml."0.5.9" { inherit profileName; }).out;
       url = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.3.1" { inherit profileName; }).out;
@@ -5264,7 +5298,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "5820a81dfb85011220d2b24323870ad30a56ae446f92b170911574c79d385bc5"; };
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       flex_error = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".flex-error."0.4.4" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
       num_traits = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-traits."0.2.15" { inherit profileName; }).out;
@@ -5296,7 +5330,7 @@ in
     ];
     dependencies = {
       async_trait = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".async-trait."0.1.58" { profileName = "__noProfile"; }).out;
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       flex_error = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".flex-error."0.4.4" { inherit profileName; }).out;
       futures = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures."0.3.25" { inherit profileName; }).out;
       getrandom = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".getrandom."0.2.8" { inherit profileName; }).out;
@@ -5308,7 +5342,7 @@ in
       pin_project = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".pin-project."1.0.12" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.147" { inherit profileName; }).out;
       serde_bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_bytes."0.11.7" { inherit profileName; }).out;
-      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.87" { inherit profileName; }).out;
+      serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.89" { inherit profileName; }).out;
       subtle = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".subtle."2.4.1" { inherit profileName; }).out;
       subtle_encoding = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".subtle-encoding."0.5.1" { inherit profileName; }).out;
       tendermint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tendermint."0.24.0-pre.2" { inherit profileName; }).out;
@@ -5316,7 +5350,7 @@ in
       tendermint_proto = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tendermint-proto."0.24.0-pre.2" { inherit profileName; }).out;
       thiserror = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".thiserror."1.0.37" { inherit profileName; }).out;
       time = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".time."0.3.17" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
       url = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.3.1" { inherit profileName; }).out;
       uuid = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".uuid."0.8.2" { inherit profileName; }).out;
@@ -5475,11 +5509,11 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"; };
   });
   
-  "registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" = overridableMkRustCrate (profileName: rec {
+  "registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" = overridableMkRustCrate (profileName: rec {
     name = "tokio";
-    version = "1.21.2";
+    version = "1.22.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
-    src = fetchCratesIo { inherit name version; sha256 = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"; };
+    src = fetchCratesIo { inherit name version; sha256 = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"; };
     features = builtins.concatLists [
       [ "bytes" ]
       [ "default" ]
@@ -5506,7 +5540,7 @@ in
       [ "winapi" ]
     ];
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       ${ if hostPlatform.isUnix then "libc" else null } = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.137" { inherit profileName; }).out;
       memchr = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.5.0" { inherit profileName; }).out;
       mio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".mio."0.8.5" { inherit profileName; }).out;
@@ -5542,7 +5576,7 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"; };
     dependencies = {
       native_tls = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".native-tls."0.2.11" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
     };
   });
   
@@ -5553,7 +5587,7 @@ in
     src = fetchCratesIo { inherit name version; sha256 = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"; };
     dependencies = {
       rustls = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustls."0.19.1" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       webpki = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".webpki."0.21.4" { inherit profileName; }).out;
     };
   });
@@ -5569,11 +5603,11 @@ in
       [ "tracing" ]
     ];
     dependencies = {
-      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.2.1" { inherit profileName; }).out;
+      bytes = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."1.3.0" { inherit profileName; }).out;
       futures_core = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-core."0.3.25" { inherit profileName; }).out;
       futures_sink = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".futures-sink."0.3.25" { inherit profileName; }).out;
       pin_project_lite = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".pin-project-lite."0.2.9" { inherit profileName; }).out;
-      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.21.2" { inherit profileName; }).out;
+      tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.22.0" { inherit profileName; }).out;
       tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing."0.1.37" { inherit profileName; }).out;
     };
   });
@@ -6113,7 +6147,7 @@ in
       [ "null-overlapped-wakeups-patch" ]
     ];
     buildDependencies = {
-      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.76" { profileName = "__noProfile"; }).out;
+      cc = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.77" { profileName = "__noProfile"; }).out;
     };
   });
   

--- a/src/http_proxy/Cargo.toml
+++ b/src/http_proxy/Cargo.toml
@@ -19,11 +19,11 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
 many-kvstore = { path = "../many-kvstore" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
 new_mime_guess = "4.0.0"
 syslog-tracing = "0.1"
 tiny_http = "0.11.0"

--- a/src/kvstore/Cargo.toml
+++ b/src/kvstore/Cargo.toml
@@ -20,13 +20,13 @@ clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 indicatif = "0.16.2"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = ["ed25519", "ecdsa"] }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = ["ed25519", "ecdsa"] }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
 syslog-tracing = "0.1"
 tracing = "0.1.29"
 tracing-subscriber = "0.3"

--- a/src/ledger-db/BUILD.bazel
+++ b/src/ledger-db/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+rust_binary(
+    name = "idstore-export",
+    srcs = glob(include=["src/**/*.rs"]),
+    aliases = aliases(),
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+    ),
+    deps = all_crate_deps(
+        normal = True,
+    ),
+)

--- a/src/ledger-db/BUILD.bazel
+++ b/src/ledger-db/BUILD.bazel
@@ -2,7 +2,7 @@ load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 rust_binary(
-    name = "idstore-export",
+    name = "ledger-db",
     srcs = glob(include=["src/**/*.rs"]),
     aliases = aliases(),
     proc_macro_deps = all_crate_deps(

--- a/src/ledger-db/Cargo.toml
+++ b/src/ledger-db/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ledger-db"
+version = "0.1.0"
+edition = "2021"
+authors = ["The Lifted Initiative"]
+license = "Apache-2.0"
+description = ""
+readme = "README.md"
+homepage = "https://liftedinit.org"
+repository = "https://github.com/liftedinit/many-framework"
+keywords = ["cli", "web3", "blockchain", "tendermint", "proto", "crypto", "liftedinit"]
+categories = ["command-line-utilities"]
+
+[[bin]]
+name = "ledger-db"
+doc = false
+
+[dependencies]
+clap = { version = "3.0.0", features = ["derive"] }
+hex = "0.4.3"
+merk = { git = "https://github.com/liftedinit/merk.git", rev = "da0b660abbfd58abd4a942773f205d2c079f3b27" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "207ca9fdd0e403b758a3a31752ab98daac14e980" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "207ca9fdd0e403b758a3a31752ab98daac14e980" }
+minicbor = "0.18.0"

--- a/src/ledger-db/Cargo.toml
+++ b/src/ledger-db/Cargo.toml
@@ -19,6 +19,6 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "da0b660abbfd58abd4a942773f205d2c079f3b27" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "207ca9fdd0e403b758a3a31752ab98daac14e980" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "207ca9fdd0e403b758a3a31752ab98daac14e980" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
 minicbor = "0.18.0"

--- a/src/ledger-db/src/main.rs
+++ b/src/ledger-db/src/main.rs
@@ -1,0 +1,48 @@
+use clap::Parser;
+use many_types::ledger::TokenAmount;
+use merk::rocksdb::{IteratorMode, ReadOptions};
+use merk::tree::Tree;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+struct Opts {
+    /// The RocksDB store to load.
+    store: PathBuf,
+}
+
+fn main() {
+    let Opts { store } = Opts::parse();
+
+    let merk = merk::Merk::open(store).expect("Could not open the store.");
+
+    let it = merk.iter_opt(IteratorMode::Start, ReadOptions::default());
+
+    for kv_result in it {
+        let (k, v) = kv_result.unwrap();
+        let new_v = Tree::decode(k.to_vec(), v.as_ref());
+
+        let k: Vec<u8> = k.into();
+        let v = new_v.value();
+
+        // Try to "smartly" decode the key.
+        if k.starts_with(b"/events/") {
+            let k = hex::encode(&k[8..]);
+            let log = minicbor::decode::<many_modules::events::EventLog>(v).unwrap();
+            println!("event {k} => {log:?}",)
+        } else if k.starts_with(b"/balances/") {
+            let k = &k[10..];
+            // This should be utf8.
+            let k = String::from_utf8_lossy(k);
+            let mut it = k.split('/');
+            let (id, symbol) = (it.next().unwrap(), it.next().unwrap());
+            let t = TokenAmount::from(v.to_vec());
+            println!("balance {id} => {t} {symbol}");
+        } else {
+            if let Ok(k) = String::from_utf8(k.clone()) {
+                println!("unknown '{}' => {}", k, hex::encode(v));
+            } else {
+                println!("unknown x {} => {}", hex::encode(k), hex::encode(v));
+            }
+        }
+    }
+}

--- a/src/ledger-db/src/main.rs
+++ b/src/ledger-db/src/main.rs
@@ -37,12 +37,10 @@ fn main() {
             let (id, symbol) = (it.next().unwrap(), it.next().unwrap());
             let t = TokenAmount::from(v.to_vec());
             println!("balance {id} => {t} {symbol}");
+        } else if let Ok(k) = String::from_utf8(k.clone()) {
+            println!("unknown '{}' => {}", k, hex::encode(v));
         } else {
-            if let Ok(k) = String::from_utf8(k.clone()) {
-                println!("unknown '{}' => {}", k, hex::encode(v));
-            } else {
-                println!("unknown x {} => {}", hex::encode(k), hex::encode(v));
-            }
+            println!("unknown 0x {} => {}", hex::encode(k), hex::encode(v));
         }
     }
 }

--- a/src/ledger-db/src/main.rs
+++ b/src/ledger-db/src/main.rs
@@ -37,8 +37,12 @@ fn main() {
             let (id, symbol) = (it.next().unwrap(), it.next().unwrap());
             let t = TokenAmount::from(v.to_vec());
             println!("balance {id} => {t} {symbol}");
+        } else if k.starts_with(b"/multisig/") {
+            let k = &k[10..];
+            let multisig = hex::encode(v);
+            println!("multisig tx 0x{} => {multisig}", hex::encode(k))
         } else if let Ok(k) = String::from_utf8(k.clone()) {
-            println!("unknown '{}' => {}", k, hex::encode(v));
+            println!("unknown {:?} => {}", k, hex::encode(v));
         } else {
             println!("unknown 0x {} => {}", hex::encode(k), hex::encode(v));
         }

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -24,14 +24,14 @@ indicatif = "0.16.2"
 lazy_static = "1.4.0"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
 num-bigint = "0.4.3"
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = ["ed25519", "ecdsa"]  }
-many-identity-hsm = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = ["ed25519", "ecdsa"]  }
+many-identity-hsm = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
 regex = "1.5.4"
 ring = "0.16.20"
 rpassword = "6.0"

--- a/src/ledger/src/multisig.rs
+++ b/src/ledger/src/multisig.rs
@@ -7,6 +7,7 @@ use many_modules::account::features::multisig;
 use many_modules::{events, ledger};
 use many_protocol::ResponseMessage;
 use many_types::ledger::TokenAmount;
+use many_types::Memo;
 use minicbor::bytes::ByteVec;
 use tracing::info;
 
@@ -118,12 +119,13 @@ fn submit_send(
     });
     let arguments = multisig::SubmitTransactionArgs {
         account,
-        memo: None,
+        memo: Some(Memo::try_from("Foo".to_string()).unwrap()),
         transaction: Box::new(transaction),
         threshold,
         timeout_in_secs: timeout.map(|d| d.as_secs()),
         execute_automatically,
-        data: None,
+        data_: None,
+        memo_: None,
     };
     let response = client.call("account.multisigSubmitTransaction", arguments)?;
 
@@ -165,7 +167,8 @@ fn submit_set_defaults(
         threshold,
         timeout_in_secs: timeout.map(|d| d.as_secs()),
         execute_automatically,
-        data: None,
+        data_: None,
+        memo_: None,
     };
     let response = client.call("account.multisigSubmitTransaction", arguments)?;
 

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -26,15 +26,15 @@ itertools = "0.10.5"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
 num-integer = "0.1.45"
 reqwest = "0.11.11"
 sha2 = "0.10.1"

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -27,13 +27,13 @@ json5 = "0.4.1"
 lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = ["default", "serde"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = ["ed25519", "ecdsa"]  }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = ["default", "serde"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = ["ed25519", "ecdsa"]  }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
 serde = "1.0.130"
 serde_json = "1.0.72"
 sha3 = "0.10.4"
@@ -47,8 +47,8 @@ tracing-subscriber = "0.3"
 
 [dev-dependencies]
 once_cell = "1.14.0"
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = ["default", "serde", "testing"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = [ "ed25519", "testing" ] }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = ["default", "serde", "testing"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = [ "ed25519", "testing" ] }
 tempfile = "3.3.0"
 
 [build-dependencies]

--- a/src/many-ledger/BUILD.bazel
+++ b/src/many-ledger/BUILD.bazel
@@ -62,7 +62,11 @@ rust_test(
 rust_test_suite(
     name = "many-ledger-test-suite",
     srcs = glob(include = ["tests/*.rs"]),
-    compile_data = ["tests/common/mod.rs"],
+    compile_data = [
+        "tests/common/mod.rs",
+        "tests/migration_/mod.rs",
+        "tests/migration_/memo.rs",
+    ],
     crate_features = ["balance_testing"],
     data = ["//:staging/ledger_state.json5"],
     proc_macro_deps = all_crate_deps(

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -31,15 +31,15 @@ linkme = { version = "0.3.5", features = ["used_linker"] }
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = ["default", "serde"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = ["ed25519", "ecdsa"]  }
-many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-migration = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = ["default", "serde"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = ["ed25519", "ecdsa"]  }
+many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-migration = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
 rand = "0.8"
 serde = "1.0.130"
 serde_json = "1.0.72"
@@ -56,9 +56,9 @@ typetag = "0.2.3"
 
 [dev-dependencies]
 once_cell = "1.12"
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = ["default", "serde", "testing"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "539f8aa33c8c8f10872373bf5665d20fafb8a7a6", features = [ "ed25519", "testing" ] }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = ["default", "serde", "testing"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ab09727a574d3abe734a374cd02e31aa6b3388f7", features = [ "ed25519", "testing" ] }
 many-ledger = { path = ".", features = ["balance_testing", "migration_testing"]}
 proptest = "1"
 tempfile = "3.3.0"

--- a/src/many-ledger/src/main.rs
+++ b/src/many-ledger/src/main.rs
@@ -5,6 +5,7 @@ use many_identity::verifiers::AnonymousVerifier;
 use many_identity::{Address, Identity};
 use many_identity_dsa::{CoseKeyIdentity, CoseKeyVerifier};
 use many_identity_webauthn::WebAuthnVerifier;
+use many_migration::MigrationConfig;
 use many_modules::account::features::Feature;
 use many_modules::{abci_backend, account, data, events, idstore, ledger};
 use many_protocol::ManyUrl;
@@ -211,7 +212,8 @@ fn main() {
     let maybe_migrations = migrations_config.map(|file| {
         let content = std::fs::read_to_string(file)
             .expect("Could not read file passed to --migrations_config");
-        serde_json::from_str(&content).unwrap()
+        let config: MigrationConfig = serde_json::from_str(&content).unwrap();
+        config.strict()
     });
 
     let module_impl = if let Some(state) = state {

--- a/src/many-ledger/src/main.rs
+++ b/src/many-ledger/src/main.rs
@@ -104,9 +104,8 @@ struct Opts {
     logmode: LogStrategy,
 
     /// Path to a JSON file containing the configurations for the
-    /// migrations
-    /// Migrations are DISABLED unless this configuration file
-    /// is given
+    /// migrations. Migrations are DISABLED unless this configuration file
+    /// is given.
     #[clap(long, short)]
     migrations_config: Option<PathBuf>,
 

--- a/src/many-ledger/src/migration.rs
+++ b/src/many-ledger/src/migration.rs
@@ -1,17 +1,18 @@
 use linkme::distributed_slice;
 use many_error::ManyError;
-use many_migration::{InnerMigration, Migration};
+use many_migration::{InnerMigration, Migration, MigrationSet};
 use std::collections::BTreeMap;
 
 pub mod block_9400;
 pub mod data;
+pub mod memo;
 
 #[cfg(feature = "migration_testing")]
 pub mod dummy_hotfix;
 
-pub type LedgerMigrations = BTreeMap<&'static str, Migration<'static, merk::Merk, ManyError>>;
+pub type LedgerMigrations = MigrationSet<'static, merk::Merk>;
 
 // This is the global migration registry
 // Doesn't contain any metadata
 #[distributed_slice]
-pub static MIGRATIONS: [InnerMigration<'static, merk::Merk, ManyError>] = [..];
+pub static MIGRATIONS: [InnerMigration<merk::Merk, ManyError>] = [..];

--- a/src/many-ledger/src/migration.rs
+++ b/src/many-ledger/src/migration.rs
@@ -1,7 +1,6 @@
 use linkme::distributed_slice;
 use many_error::ManyError;
-use many_migration::{InnerMigration, Migration, MigrationSet};
-use std::collections::BTreeMap;
+use many_migration::{InnerMigration, MigrationSet};
 
 pub mod block_9400;
 pub mod data;

--- a/src/many-ledger/src/migration/data.rs
+++ b/src/many-ledger/src/migration/data.rs
@@ -97,12 +97,12 @@ fn initialize(storage: &mut merk::Merk) -> Result<(), ManyError> {
 }
 
 #[distributed_slice(MIGRATIONS)]
-static ACCOUNT_COUNT_DATA_ATTRIBUTE: InnerMigration<merk::Merk, ManyError> =
+pub static ACCOUNT_COUNT_DATA_ATTRIBUTE: InnerMigration<merk::Merk, ManyError> =
     InnerMigration::new_initialize(
         initialize,
         "Account Count Data Attribute",
         r#"
-            Provides the total number of unique addresses. 
+            Provides the total number of unique addresses.
             Provides the total number of unique addresses with a non-zero balance.
             "#,
     );

--- a/src/many-ledger/src/migration/memo.rs
+++ b/src/many-ledger/src/migration/memo.rs
@@ -1,18 +1,33 @@
 use crate::migration::MIGRATIONS;
 use crate::storage::event::LedgerIterator;
+use crate::storage::multisig::MultisigTransactionStorage;
 use linkme::distributed_slice;
 use many_error::ManyError;
 use many_migration::InnerMigration;
+use many_modules::account::features::multisig::InfoReturn;
 use many_modules::events::{EventInfo, EventLog};
-use many_types::Memo;
+use many_types::{Memo, SortOrder};
 use merk::Op;
 
 fn iter_through_events(
     storage: &merk::Merk,
 ) -> impl Iterator<Item = Result<(Vec<u8>, EventLog), ManyError>> + '_ {
-    LedgerIterator::all(storage).map(|r| match r {
+    LedgerIterator::all_events(storage).map(|r| match r {
         Ok((k, v)) => {
             let log = minicbor::decode::<EventLog>(v.as_slice())
+                .map_err(ManyError::deserialization_error)?;
+            Ok((k.into(), log))
+        }
+        Err(e) => Err(ManyError::unknown(e)),
+    })
+}
+
+fn iter_through_multisig_storage(
+    storage: &merk::Merk,
+) -> impl Iterator<Item = Result<(Vec<u8>, MultisigTransactionStorage), ManyError>> + '_ {
+    LedgerIterator::all_multisig(storage, SortOrder::Ascending).map(|r| match r {
+        Ok((k, v)) => {
+            let log = minicbor::decode::<MultisigTransactionStorage>(v.as_slice())
                 .map_err(ManyError::deserialization_error)?;
             Ok((k.into(), log))
         }
@@ -88,9 +103,74 @@ fn update_multisig_submit_events(storage: &mut merk::Merk) -> Result<(), ManyErr
     Ok(())
 }
 
+fn update_multisig_storage(storage: &mut merk::Merk) -> Result<(), ManyError> {
+    let mut batch = Vec::new();
+
+    for multisig in iter_through_multisig_storage(storage) {
+        let (
+            key,
+            MultisigTransactionStorage {
+                account,
+                info,
+                creation,
+                disabled,
+            },
+        ) = multisig?;
+
+        if info.memo.is_some() {
+            continue;
+        }
+
+        let new_memo = match (info.memo_, info.data_) {
+            (Some(m), Some(d)) => {
+                let mut memo = Memo::from(m);
+                memo.push_bytes(d.as_bytes().to_vec())?;
+                Some(memo)
+            }
+            (Some(m), _) => Some(Memo::from(m)),
+            (_, Some(d)) => Some(Memo::from(d)),
+            _ => None,
+        };
+
+        if let Some(memo) = new_memo {
+            let new_multisig = MultisigTransactionStorage {
+                account,
+                creation,
+                info: InfoReturn {
+                    memo_: None,
+                    data_: None,
+                    memo: Some(memo),
+                    ..info
+                },
+                disabled,
+            };
+
+            batch.push((
+                key,
+                Op::Put(minicbor::to_vec(new_multisig).map_err(ManyError::serialization_error)?),
+            ));
+        }
+    }
+
+    // The iterator is already sorted when going through rocksdb.
+    // Since we only filter and map above, the keys in batch will always
+    // be sorted at this point.
+    storage
+        .apply(batch.as_slice())
+        .map_err(ManyError::unknown)?;
+    storage.commit(&[]).map_err(ManyError::unknown)?;
+    Ok(())
+}
+
+fn initialize(storage: &mut merk::Merk) -> Result<(), ManyError> {
+    update_multisig_submit_events(storage)?;
+    update_multisig_storage(storage)?;
+    Ok(())
+}
+
 #[distributed_slice(MIGRATIONS)]
 pub static MEMO_MIGRATION: InnerMigration<merk::Merk, ManyError> = InnerMigration::new_initialize(
-    update_multisig_submit_events,
+    initialize,
     "Memo Migration",
     "Move the database from legacy memo and data to the new memo data type.",
 );

--- a/src/many-ledger/src/migration/memo.rs
+++ b/src/many-ledger/src/migration/memo.rs
@@ -45,7 +45,7 @@ fn update_multisig_submit_events(storage: &mut merk::Merk) -> Result<(), ManyErr
             let memo = match (memo_, data_) {
                 (Some(m), Some(d)) => {
                     let mut m = Memo::from(m);
-                    m.push_byte_vec(d.as_bytes().to_vec().into())?;
+                    m.push_bytes(d.as_bytes().to_vec())?;
                     Some(m)
                 }
                 (Some(m), _) => Some(Memo::from(m)),

--- a/src/many-ledger/src/migration/memo.rs
+++ b/src/many-ledger/src/migration/memo.rs
@@ -78,6 +78,9 @@ fn update_multisig_submit_events(storage: &mut merk::Merk) -> Result<(), ManyErr
         }
     }
 
+    // The iterator is already sorted when going through rocksdb.
+    // Since we only filter and map above, the keys in batch will always
+    // be sorted at this point.
     storage
         .apply(batch.as_slice())
         .map_err(ManyError::unknown)?;
@@ -85,15 +88,9 @@ fn update_multisig_submit_events(storage: &mut merk::Merk) -> Result<(), ManyErr
     Ok(())
 }
 
-fn initialize(storage: &mut merk::Merk) -> Result<(), ManyError> {
-    update_multisig_submit_events(storage)?;
-
-    Ok(())
-}
-
 #[distributed_slice(MIGRATIONS)]
 pub static MEMO_MIGRATION: InnerMigration<merk::Merk, ManyError> = InnerMigration::new_initialize(
-    initialize,
+    update_multisig_submit_events,
     "Memo Migration",
     "Move the database from legacy memo and data to the new memo data type.",
 );

--- a/src/many-ledger/src/migration/memo.rs
+++ b/src/many-ledger/src/migration/memo.rs
@@ -1,0 +1,99 @@
+use crate::migration::MIGRATIONS;
+use crate::storage::event::LedgerIterator;
+use linkme::distributed_slice;
+use many_error::ManyError;
+use many_migration::InnerMigration;
+use many_modules::events::{EventInfo, EventLog};
+use many_types::Memo;
+use merk::Op;
+
+fn iter_through_events(
+    storage: &merk::Merk,
+) -> impl Iterator<Item = Result<(Vec<u8>, EventLog), ManyError>> + '_ {
+    LedgerIterator::all(storage).map(|r| match r {
+        Ok((k, v)) => {
+            let log = minicbor::decode::<EventLog>(v.as_slice())
+                .map_err(ManyError::deserialization_error)?;
+            Ok((k.into(), log))
+        }
+        Err(e) => Err(ManyError::unknown(e)),
+    })
+}
+
+fn update_multisig_submit_events(storage: &mut merk::Merk) -> Result<(), ManyError> {
+    let mut batch = Vec::new();
+
+    for log in iter_through_events(storage) {
+        let (key, EventLog { id, time, content }) = log?;
+
+        if let EventInfo::AccountMultisigSubmit {
+            submitter,
+            account,
+            memo_,
+            transaction,
+            token,
+            threshold,
+            timeout,
+            execute_automatically,
+            data_,
+            memo,
+        } = content
+        {
+            if memo.is_some() {
+                continue;
+            }
+            let memo = match (memo_, data_) {
+                (Some(m), Some(d)) => {
+                    let mut m = Memo::from(m);
+                    m.push_byte_vec(d.as_bytes().to_vec().into())?;
+                    Some(m)
+                }
+                (Some(m), _) => Some(Memo::from(m)),
+                (_, Some(d)) => Some(Memo::from(d)),
+                _ => None,
+            };
+
+            if let Some(memo) = memo {
+                let new_log = EventLog {
+                    id,
+                    time,
+                    content: EventInfo::AccountMultisigSubmit {
+                        submitter,
+                        account,
+                        memo_: None,
+                        transaction,
+                        token,
+                        threshold,
+                        timeout,
+                        execute_automatically,
+                        data_: None,
+                        memo: Some(memo),
+                    },
+                };
+                batch.push((
+                    key,
+                    Op::Put(minicbor::to_vec(new_log).map_err(ManyError::serialization_error)?),
+                ));
+            }
+        }
+    }
+
+    storage
+        .apply(batch.as_slice())
+        .map_err(ManyError::unknown)?;
+    storage.commit(&[]).map_err(ManyError::unknown)?;
+    Ok(())
+}
+
+fn initialize(storage: &mut merk::Merk) -> Result<(), ManyError> {
+    update_multisig_submit_events(storage)?;
+
+    Ok(())
+}
+
+#[distributed_slice(MIGRATIONS)]
+pub static MEMO_MIGRATION: InnerMigration<merk::Merk, ManyError> = InnerMigration::new_initialize(
+    initialize,
+    "Memo Migration",
+    "Move the database from legacy memo and data to the new memo data type.",
+);

--- a/src/many-ledger/src/module.rs
+++ b/src/many-ledger/src/module.rs
@@ -1,8 +1,9 @@
+use crate::error;
 use crate::json::InitialStateJson;
-use crate::migration::LedgerMigrations;
-use crate::{error, storage::LedgerStorage};
+use crate::storage::LedgerStorage;
 use many_error::ManyError;
 use many_identity::Address;
+use many_migration::MigrationConfig;
 use many_types::ledger::Symbol;
 use std::fmt::Debug;
 use std::path::Path;
@@ -28,7 +29,7 @@ pub struct LedgerModuleImpl {
 impl LedgerModuleImpl {
     pub fn new<P: AsRef<Path>>(
         state: InitialStateJson,
-        migrations: Option<LedgerMigrations>,
+        migration_config: Option<MigrationConfig>,
         persistence_store_path: P,
         blockchain: bool,
     ) -> Result<Self, ManyError> {
@@ -48,6 +49,7 @@ impl LedgerModuleImpl {
                     })
                     .collect()
             }),
+            migration_config.unwrap_or_default(),
         )
         .map_err(ManyError::unknown)?;
 
@@ -68,10 +70,6 @@ impl LedgerModuleImpl {
             }
         }
 
-        if let Some(migrations) = migrations {
-            storage.set_migrations(migrations)
-        }
-
         info!(
             height = storage.get_height(),
             hash = hex::encode(storage.hash()).as_str()
@@ -83,15 +81,16 @@ impl LedgerModuleImpl {
     }
 
     pub fn load<P: AsRef<Path>>(
-        migrations: Option<LedgerMigrations>,
+        migrations: Option<MigrationConfig>,
         persistence_store_path: P,
         blockchain: bool,
     ) -> Result<Self, ManyError> {
-        let mut storage = LedgerStorage::load(persistence_store_path, blockchain).unwrap();
-
-        if let Some(migrations) = migrations {
-            storage.set_migrations(migrations)
-        }
+        let storage = LedgerStorage::load(
+            persistence_store_path,
+            blockchain,
+            migrations.unwrap_or_default(),
+        )
+        .unwrap();
 
         tracing::debug!("Final migrations: {:?}", storage.migrations());
 

--- a/src/many-ledger/src/module.rs
+++ b/src/many-ledger/src/module.rs
@@ -47,7 +47,7 @@ impl LedgerModuleImpl {
                     })
                     .collect()
             }),
-            migration_config.unwrap_or_default(),
+            migration_config,
         )
         .map_err(ManyError::unknown)?;
 
@@ -83,12 +83,7 @@ impl LedgerModuleImpl {
         persistence_store_path: P,
         blockchain: bool,
     ) -> Result<Self, ManyError> {
-        let storage = LedgerStorage::load(
-            persistence_store_path,
-            blockchain,
-            migrations.unwrap_or_default(),
-        )
-        .unwrap();
+        let storage = LedgerStorage::load(persistence_store_path, blockchain, migrations).unwrap();
 
         tracing::debug!("Final migrations: {:?}", storage.migrations());
 

--- a/src/many-ledger/src/module/event.rs
+++ b/src/many-ledger/src/module/event.rs
@@ -138,7 +138,7 @@ impl events::EventsModuleBackend for LedgerModuleImpl {
 
         let storage = &self.storage;
         let nb_events = storage.nb_events();
-        let iter = storage.iter(
+        let iter = storage.iter_events(
             filter.id_range.unwrap_or_default(),
             order.unwrap_or_default(),
         );

--- a/src/many-ledger/src/storage.rs
+++ b/src/many-ledger/src/storage.rs
@@ -6,7 +6,7 @@ use many_migration::{MigrationConfig, MigrationSet};
 use many_modules::events::EventId;
 use many_types::ledger::{Symbol, TokenAmount};
 use many_types::Timestamp;
-use merk::{rocksdb, BatchEntry, Op};
+use merk::{BatchEntry, Op};
 use std::collections::BTreeMap;
 use std::path::Path;
 

--- a/src/many-ledger/src/storage.rs
+++ b/src/many-ledger/src/storage.rs
@@ -251,12 +251,15 @@ impl LedgerStorage {
         F: FnOnce() -> T,
     >(
         &mut self,
-        _name: &str,
+        name: &str,
         data: F,
     ) -> Result<Option<C>, ManyError> {
         let data_enc = minicbor::to_vec(data()).map_err(ManyError::serialization_error)?;
 
-        if let Some(data) = self.migrations.hotfix(&data_enc, self.get_height() + 1)? {
+        if let Some(data) = self
+            .migrations
+            .hotfix(name, &data_enc, self.get_height() + 1)?
+        {
             let dec_data = minicbor::decode(&data).map_err(ManyError::deserialization_error)?;
             Ok(Some(dec_data))
         } else {

--- a/src/many-ledger/src/storage.rs
+++ b/src/many-ledger/src/storage.rs
@@ -1,8 +1,8 @@
-use crate::migration::LedgerMigrations;
+use crate::migration::{LedgerMigrations, MIGRATIONS};
 use crate::storage::event::HEIGHT_EVENTID_SHIFT;
 use many_error::ManyError;
 use many_identity::Address;
-use many_migration::InnerMigration;
+use many_migration::MigrationConfig;
 use many_modules::events::EventId;
 use many_types::ledger::{Symbol, TokenAmount};
 use many_types::Timestamp;
@@ -86,24 +86,15 @@ impl LedgerStorage {
         self.current_time.unwrap_or_else(Timestamp::now)
     }
 
-    pub(crate) fn set_migrations(&mut self, migrations: LedgerMigrations) {
-        self.migrations = migrations
-    }
-
     pub fn migrations(&self) -> &LedgerMigrations {
         &self.migrations
     }
 
-    /// TODO: refactor this to be part of the LedgerMigrations type.
-    pub fn has_migration<T, E>(&self, migration: &InnerMigration<T, E>) -> bool {
-        if let Some(mig) = self.migrations.get(migration.name()) {
-            mig.is_enabled()
-        } else {
-            false
-        }
-    }
-
-    pub fn load<P: AsRef<Path>>(persistent_path: P, blockchain: bool) -> Result<Self, String> {
+    pub fn load<P: AsRef<Path>>(
+        persistent_path: P,
+        blockchain: bool,
+        migration_config: MigrationConfig,
+    ) -> Result<Self, String> {
         let persistent_store = merk::Merk::open(persistent_path).map_err(|e| e.to_string())?;
 
         let symbols = persistent_store
@@ -146,7 +137,7 @@ impl LedgerStorage {
             current_hash: None,
             next_account_id,
             account_identity,
-            migrations: LedgerMigrations::new(),
+            migrations: LedgerMigrations::load(&MIGRATIONS, migration_config, height)?,
         })
     }
 
@@ -158,6 +149,7 @@ impl LedgerStorage {
         blockchain: bool,
         maybe_seed: Option<u64>,
         maybe_keys: Option<BTreeMap<Vec<u8>, Vec<u8>>>,
+        migration_config: MigrationConfig,
     ) -> Result<Self, String> {
         let mut persistent_store = merk::Merk::open(persistent_path).map_err(|e| e.to_string())?;
 
@@ -210,7 +202,7 @@ impl LedgerStorage {
             current_hash: None,
             next_account_id: 0,
             account_identity: identity,
-            migrations: LedgerMigrations::new(),
+            migrations: LedgerMigrations::load(&MIGRATIONS, migration_config, 0)?,
         })
     }
 
@@ -257,26 +249,17 @@ impl LedgerStorage {
         C: for<'a> minicbor::Decode<'a, ()>,
         F: FnOnce() -> T,
     >(
-        &self,
-        name: &str,
+        &mut self,
+        _name: &str,
         data: F,
     ) -> Result<Option<C>, ManyError> {
-        if let Some(migration) = self.migrations.get(name) {
-            // We are building the current block so the correct height is the current height (finished blocks) + 1
-            if self.get_height() + 1 == migration.metadata.block_height && migration.is_enabled() {
-                let data_enc = minicbor::to_vec(data()).map_err(ManyError::serialization_error)?;
-                let new_data = migration.hotfix(&data_enc, self.get_height() + 1);
-                if let Some(new_data) = new_data {
-                    return Ok(Some(
-                        minicbor::decode(&new_data).map_err(ManyError::deserialization_error)?,
-                    ));
-                }
-                return Err(ManyError::unknown(
-                    "Something went wrong while running migration \"{name}\"",
-                ));
-            }
-            return Ok(None);
+        let data_enc = minicbor::to_vec(data()).map_err(ManyError::serialization_error)?;
+
+        if let Some(data) = self.migrations.hotfix(&data_enc, self.get_height() + 1)? {
+            let dec_data = minicbor::decode(&data).map_err(ManyError::deserialization_error)?;
+            Ok(Some(dec_data))
+        } else {
+            Ok(None)
         }
-        Ok(None)
     }
 }

--- a/src/many-ledger/src/storage.rs
+++ b/src/many-ledger/src/storage.rs
@@ -2,6 +2,7 @@ use crate::migration::LedgerMigrations;
 use crate::storage::event::HEIGHT_EVENTID_SHIFT;
 use many_error::ManyError;
 use many_identity::Address;
+use many_migration::InnerMigration;
 use many_modules::events::EventId;
 use many_types::ledger::{Symbol, TokenAmount};
 use many_types::Timestamp;
@@ -91,6 +92,15 @@ impl LedgerStorage {
 
     pub fn migrations(&self) -> &LedgerMigrations {
         &self.migrations
+    }
+
+    /// TODO: refactor this to be part of the LedgerMigrations type.
+    pub fn has_migration<T, E>(&self, migration: &InnerMigration<T, E>) -> bool {
+        if let Some(mig) = self.migrations.get(migration.name()) {
+            mig.is_enabled()
+        } else {
+            false
+        }
     }
 
     pub fn load<P: AsRef<Path>>(persistent_path: P, blockchain: bool) -> Result<Self, String> {

--- a/src/many-ledger/src/storage.rs
+++ b/src/many-ledger/src/storage.rs
@@ -141,6 +141,7 @@ impl LedgerStorage {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new<P: AsRef<Path>>(
         symbols: BTreeMap<Symbol, String>,
         initial_balances: BTreeMap<Address, BTreeMap<Symbol, TokenAmount>>,

--- a/src/many-ledger/src/storage/abci.rs
+++ b/src/many-ledger/src/storage/abci.rs
@@ -19,7 +19,7 @@ impl LedgerStorage {
 
         // Initialize/update migrations at current height, if any
         self.migrations
-            .update(&mut self.persistent_store, height + 1)
+            .update_at_height(&mut self.persistent_store, height + 1)
             .expect("Unable to run migrations");
 
         self.persistent_store.commit(&[]).unwrap();

--- a/src/many-ledger/src/storage/abci.rs
+++ b/src/many-ledger/src/storage/abci.rs
@@ -18,14 +18,9 @@ impl LedgerStorage {
         self.persistent_store.commit(&[]).unwrap();
 
         // Initialize/update migrations at current height, if any
-        for migration in self.migrations.values() {
-            migration
-                .initialize(&mut self.persistent_store, height + 1)
-                .expect("Unable to initialize migration");
-            migration
-                .update(&mut self.persistent_store, height + 1)
-                .expect("Unable to perform migration update");
-        }
+        self.migrations
+            .update(&mut self.persistent_store, height + 1)
+            .expect("Unable to run migrations");
 
         self.persistent_store.commit(&[]).unwrap();
 

--- a/src/many-ledger/src/storage/event.rs
+++ b/src/many-ledger/src/storage/event.rs
@@ -2,7 +2,7 @@ use crate::storage::LedgerStorage;
 use many_modules::events;
 use many_modules::events::EventId;
 use many_types::{CborRange, SortOrder};
-use merk::rocksdb::ReadOptions;
+use merk::rocksdb::{Direction, ReadOptions};
 use merk::tree::Tree;
 use merk::{rocksdb, Op};
 use std::ops::{Bound, RangeBounds};
@@ -74,8 +74,12 @@ impl LedgerStorage {
         }
     }
 
-    pub fn iter(&self, range: CborRange<EventId>, order: SortOrder) -> LedgerIterator {
-        LedgerIterator::scoped_by_id(&self.persistent_store, range, order)
+    pub fn iter_multisig(&self, order: SortOrder) -> LedgerIterator {
+        LedgerIterator::all_multisig(&self.persistent_store, order)
+    }
+
+    pub fn iter_events(&self, range: CborRange<EventId>, order: SortOrder) -> LedgerIterator {
+        LedgerIterator::events_scoped_by_id(&self.persistent_store, range, order)
     }
 }
 
@@ -125,11 +129,40 @@ pub struct LedgerIterator<'a> {
 }
 
 impl<'a> LedgerIterator<'a> {
-    pub fn all(merk: &'a merk::Merk) -> Self {
-        Self::scoped_by_id(merk, CborRange::default(), SortOrder::Indeterminate)
+    pub fn all_multisig(merk: &'a merk::Merk, order: SortOrder) -> Self {
+        use crate::storage::multisig::MULTISIG_TRANSACTIONS_ROOT;
+        use rocksdb::IteratorMode;
+
+        // Set the iterator bounds to iterate all multisig transactions.
+        // We will break the loop later if we can.
+        let mut options = ReadOptions::default();
+        options.set_iterate_lower_bound(MULTISIG_TRANSACTIONS_ROOT);
+
+        let mut bound = MULTISIG_TRANSACTIONS_ROOT.to_vec();
+        bound[MULTISIG_TRANSACTIONS_ROOT.len() - 1] += 1;
+        options.set_iterate_upper_bound(bound.clone());
+
+        let it_mode = match order {
+            SortOrder::Indeterminate | SortOrder::Ascending => {
+                IteratorMode::From(MULTISIG_TRANSACTIONS_ROOT, Direction::Forward)
+            }
+            SortOrder::Descending => IteratorMode::From(&bound, Direction::Reverse),
+        };
+
+        let inner = merk.iter_opt(it_mode, options);
+
+        Self { inner }
     }
 
-    pub fn scoped_by_id(merk: &'a merk::Merk, range: CborRange<EventId>, order: SortOrder) -> Self {
+    pub fn all_events(merk: &'a merk::Merk) -> Self {
+        Self::events_scoped_by_id(merk, CborRange::default(), SortOrder::Indeterminate)
+    }
+
+    pub fn events_scoped_by_id(
+        merk: &'a merk::Merk,
+        range: CborRange<EventId>,
+        order: SortOrder,
+    ) -> Self {
         use rocksdb::IteratorMode;
         let mut opts = ReadOptions::default();
 

--- a/src/many-ledger/src/storage/event.rs
+++ b/src/many-ledger/src/storage/event.rs
@@ -125,6 +125,10 @@ pub struct LedgerIterator<'a> {
 }
 
 impl<'a> LedgerIterator<'a> {
+    pub fn all(merk: &'a merk::Merk) -> Self {
+        Self::scoped_by_id(merk, CborRange::default(), SortOrder::Indeterminate)
+    }
+
     pub fn scoped_by_id(merk: &'a merk::Merk, range: CborRange<EventId>, order: SortOrder) -> Self {
         use rocksdb::IteratorMode;
         let mut opts = ReadOptions::default();

--- a/src/many-ledger/src/storage/multisig.rs
+++ b/src/many-ledger/src/storage/multisig.rs
@@ -316,7 +316,6 @@ impl LedgerStorage {
         sender: &Address,
         arg: account::features::multisig::SubmitTransactionArgs,
     ) -> Result<Vec<u8>, ManyError> {
-        eprintln!("arg: {:?}", arg);
         let event_id = self.new_event_id();
         let account_id = arg.account;
 
@@ -381,20 +380,19 @@ impl LedgerStorage {
         } else {
             (arg.memo_, arg.data_, None)
         };
-        eprintln!("memo: ({memo_:?}, {data_:?}, {memo:?})");
 
         let storage = MultisigTransactionStorage {
             account: account_id,
             info: account::features::multisig::InfoReturn {
-                memo_,
-                memo,
+                memo_: memo_.clone(),
+                memo: memo.clone(),
                 transaction: arg.transaction.as_ref().clone(),
                 submitter: *sender,
                 approvers,
                 threshold,
                 execute_automatically,
                 timeout,
-                data_,
+                data_: data_.clone(),
                 state: account::features::multisig::MultisigTransactionState::Pending,
             },
             creation: self.now().as_system_time()?,
@@ -405,14 +403,14 @@ impl LedgerStorage {
         self.log_event(events::EventInfo::AccountMultisigSubmit {
             submitter: *sender,
             account: account_id,
-            memo_: None,
+            memo_,
             transaction: Box::new(*arg.transaction),
             token: Some(event_id.clone().into()),
             threshold,
             timeout,
             execute_automatically,
-            data_: None,
-            memo: arg.memo,
+            data_,
+            memo,
         });
 
         Ok(event_id.into())

--- a/src/many-ledger/src/storage/multisig.rs
+++ b/src/many-ledger/src/storage/multisig.rs
@@ -374,6 +374,7 @@ impl LedgerStorage {
         let storage = MultisigTransactionStorage {
             account: account_id,
             info: account::features::multisig::InfoReturn {
+                memo_: None,
                 memo: arg.memo.clone(),
                 transaction: arg.transaction.as_ref().clone(),
                 submitter: *sender,
@@ -381,7 +382,7 @@ impl LedgerStorage {
                 threshold,
                 execute_automatically,
                 timeout,
-                data: arg.data.clone(),
+                data_: None,
                 state: account::features::multisig::MultisigTransactionState::Pending,
             },
             creation: self.now().as_system_time()?,
@@ -392,13 +393,14 @@ impl LedgerStorage {
         self.log_event(events::EventInfo::AccountMultisigSubmit {
             submitter: *sender,
             account: account_id,
-            memo: arg.memo,
+            memo_: None,
             transaction: Box::new(*arg.transaction),
             token: Some(event_id.clone().into()),
             threshold,
             timeout,
             execute_automatically,
-            data: arg.data,
+            data_: None,
+            memo: arg.memo,
         });
 
         Ok(event_id.into())

--- a/src/many-ledger/tests/common/mod.rs
+++ b/src/many-ledger/tests/common/mod.rs
@@ -167,7 +167,7 @@ impl Setup {
         migrations: impl IntoIterator<Item = impl Into<MigrationHarness>>,
     ) -> Self {
         let migrations = format!(
-            "[{}]",
+            r#"{{ "migrations": [{}] }}"#,
             migrations
                 .into_iter()
                 .map(|x| x.into().to_json_str())

--- a/src/many-ledger/tests/common/mod.rs
+++ b/src/many-ledger/tests/common/mod.rs
@@ -37,8 +37,8 @@ pub struct MigrationHarness {
 
 impl MigrationHarness {
     pub fn to_json_str(&self) -> String {
-        let maybe_enabled = if self.enabled {
-            r#", "status": "Disabled""#
+        let maybe_enabled = if !self.enabled {
+            r#", "disabled": true"#
         } else {
             ""
         };

--- a/src/many-ledger/tests/common/mod.rs
+++ b/src/many-ledger/tests/common/mod.rs
@@ -56,7 +56,7 @@ impl From<(u64, &'static InnerMigration<merk::Merk, ManyError>)> for MigrationHa
         MigrationHarness {
             inner,
             block_height,
-            enabled: false,
+            enabled: true,
         }
     }
 }

--- a/src/many-ledger/tests/common/mod.rs
+++ b/src/many-ledger/tests/common/mod.rs
@@ -27,7 +27,6 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     str::FromStr,
 };
-use tracing::debug;
 
 pub struct MigrationHarness {
     inner: &'static InnerMigration<merk::Merk, ManyError>,
@@ -139,7 +138,7 @@ impl Setup {
         let public_key = PublicKey(id.public_key().to_vec().unwrap().into());
 
         let store_path = tempfile::tempdir().expect("Could not create a temporary dir.");
-        debug!("Store path: {:?}", store_path.path());
+        eprintln!("Store path: {:?}", store_path.path());
 
         Self {
             module_impl: LedgerModuleImpl::new(

--- a/src/many-ledger/tests/common/mod.rs
+++ b/src/many-ledger/tests/common/mod.rs
@@ -138,6 +138,11 @@ impl Setup {
         let public_key = PublicKey(id.public_key().to_vec().unwrap().into());
 
         let store_path = tempfile::tempdir().expect("Could not create a temporary dir.");
+
+        // In tests we cannot log using the trace crate as there's no subscriber.
+        // Instead we just allow this single `eprintln` which is actually useful
+        // when debugging.
+        #[allow(clippy::print_stderr)]
         eprintln!("Store path: {:?}", store_path.path());
 
         Self {

--- a/src/many-ledger/tests/common/mod.rs
+++ b/src/many-ledger/tests/common/mod.rs
@@ -9,7 +9,7 @@ use many_ledger::module::LedgerModuleImpl;
 use many_migration::load_migrations;
 use many_modules::abci_backend::{AbciBlock, ManyAbciModuleBackend};
 use many_modules::account::features::multisig::{
-    AccountMultisigModuleBackend, ExecuteArgs, InfoReturn, Memo,
+    AccountMultisigModuleBackend, ExecuteArgs, InfoReturn,
 };
 use many_modules::account::features::FeatureInfo;
 use many_modules::account::AccountModuleBackend;
@@ -18,6 +18,7 @@ use many_modules::ledger::{BalanceArgs, LedgerCommandsModuleBackend, LedgerModul
 use many_modules::{account, events, ledger};
 use many_protocol::ResponseMessage;
 use many_types::ledger::{Symbol, TokenAmount};
+use many_types::Memo;
 use minicbor::bytes::ByteVec;
 use once_cell::sync::Lazy;
 use proptest::prelude::*;
@@ -273,7 +274,8 @@ impl Setup {
                     threshold: None,
                     timeout_in_secs: None,
                     execute_automatically: None,
-                    data: None,
+                    data_: None,
+                    memo_: None,
                 },
             )
             .map(|x| x.token)
@@ -491,7 +493,8 @@ fn event_from_kind(
                     threshold: None,
                     timeout_in_secs: None,
                     execute_automatically: Some(false),
-                    data: None,
+                    data_: None,
+                    memo_: None,
                 },
             )
         }
@@ -506,7 +509,8 @@ fn event_from_kind(
                         threshold: None,
                         timeout_in_secs: None,
                         execute_automatically: Some(false),
-                        data: None,
+                        data_: None,
+                        memo_: None,
                     },
                 )
                 .unwrap()
@@ -526,7 +530,8 @@ fn event_from_kind(
                         threshold: None,
                         timeout_in_secs: None,
                         execute_automatically: Some(false),
-                        data: None,
+                        data_: None,
+                        memo_: None,
                     },
                 )
                 .unwrap()
@@ -547,7 +552,8 @@ fn event_from_kind(
                         threshold: None,
                         timeout_in_secs: None,
                         execute_automatically: Some(false),
-                        data: None,
+                        data_: None,
+                        memo_: None,
                     },
                 )
                 .unwrap()
@@ -574,7 +580,8 @@ fn event_from_kind(
                         threshold: None,
                         timeout_in_secs: None,
                         execute_automatically: Some(false),
-                        data: None,
+                        data_: None,
+                        memo_: None,
                     },
                 )
                 .unwrap()

--- a/src/many-ledger/tests/events.rs
+++ b/src/many-ledger/tests/events.rs
@@ -5,14 +5,14 @@ use many_identity::testing::identity;
 use many_identity::Address;
 use many_ledger::module::LedgerModuleImpl;
 use many_modules::account::features::multisig::{
-    self, AccountMultisigModuleBackend, Memo, MultisigTransactionState,
+    self, AccountMultisigModuleBackend, MultisigTransactionState,
 };
 use many_modules::events::{
     self, EventFilterAttributeSpecific, EventFilterAttributeSpecificIndex, EventsModuleBackend,
 };
 use many_modules::ledger;
 use many_modules::ledger::LedgerCommandsModuleBackend;
-use many_types::{CborRange, Timestamp};
+use many_types::{CborRange, Memo, Timestamp};
 use proptest::prelude::*;
 use proptest::test_runner::Config;
 use std::collections::BTreeMap;
@@ -227,7 +227,8 @@ fn submit_args(
         threshold: None,
         timeout_in_secs: None,
         execute_automatically,
-        data: None,
+        data_: None,
+        memo_: None,
     }
 }
 

--- a/src/many-ledger/tests/events.rs
+++ b/src/many-ledger/tests/events.rs
@@ -20,6 +20,10 @@ use std::ops::Bound;
 
 fn send(module_impl: &mut LedgerModuleImpl, from: Address, to: Address) {
     module_impl.set_balance_only_for_testing(from, 1000, *MFX_SYMBOL);
+    send_(module_impl, from, to);
+}
+
+fn send_(module_impl: &mut LedgerModuleImpl, from: Address, to: Address) {
     let result = module_impl.send(
         &from,
         ledger::SendArgs {
@@ -65,6 +69,103 @@ fn list() {
     let list_return = result.unwrap();
     assert_eq!(list_return.nb_events, 1);
     assert_eq!(list_return.events.len(), 1);
+}
+
+#[test]
+fn list_many() {
+    let Setup {
+        mut module_impl,
+        id,
+        ..
+    } = setup();
+
+    send(&mut module_impl, id, identity(1));
+    let result = module_impl.list(events::ListArgs {
+        count: None,
+        order: None,
+        filter: None,
+    });
+    assert!(result.is_ok());
+    let list_return = result.unwrap();
+    assert_eq!(list_return.nb_events, 1);
+    assert_eq!(list_return.events.len(), 1);
+
+    send(&mut module_impl, id, identity(1));
+    let list_return = module_impl
+        .list(events::ListArgs {
+            count: None,
+            order: None,
+            filter: None,
+        })
+        .unwrap();
+    assert_eq!(list_return.nb_events, 2);
+    assert_eq!(list_return.events.len(), 2);
+
+    send(&mut module_impl, identity(1), identity(2));
+    let list_return = module_impl
+        .list(events::ListArgs {
+            count: None,
+            order: None,
+            filter: None,
+        })
+        .unwrap();
+    assert_eq!(list_return.nb_events, 3);
+    assert_eq!(list_return.events.len(), 3);
+
+    let list_return = module_impl
+        .list(events::ListArgs {
+            count: Some(2),
+            order: None,
+            filter: None,
+        })
+        .unwrap();
+    assert_eq!(list_return.nb_events, 3);
+    assert_eq!(list_return.events.len(), 2);
+}
+
+#[test]
+fn list_blockchain() {
+    let mut setup = Setup::new(true);
+    let id = setup.id;
+    setup.set_balance(id, 1000, *MFX_SYMBOL);
+    setup.block(|_| {});
+
+    let result = setup.module_impl.list(events::ListArgs {
+        count: None,
+        order: None,
+        filter: None,
+    });
+    assert!(result.is_ok());
+    let list_return = result.unwrap();
+    assert_eq!(list_return.nb_events, 0);
+    assert_eq!(list_return.events.len(), 0);
+
+    for i in 1..=3 {
+        setup.block(|setup| {
+            send_(&mut setup.module_impl, id, identity(1));
+        });
+        let list_return = setup
+            .module_impl
+            .list(events::ListArgs {
+                count: None,
+                order: None,
+                filter: None,
+            })
+            .unwrap();
+        assert_eq!(list_return.nb_events, i);
+        assert_eq!(list_return.events.len(), i as usize);
+    }
+
+    let list_return = setup
+        .module_impl
+        .list(events::ListArgs {
+            count: Some(2),
+            order: None,
+            filter: None,
+        })
+        .unwrap();
+    assert_eq!(list_return.nb_events, 3);
+    assert_eq!(list_return.events.len(), 2);
 }
 
 #[test]

--- a/src/many-ledger/tests/iterator.rs
+++ b/src/many-ledger/tests/iterator.rs
@@ -47,8 +47,7 @@ fn iter_asc(
     end: Bound<EventId>,
 ) -> impl Iterator<Item = EventLog> + '_ {
     storage
-        .iter(CborRange { start, end }, SortOrder::Ascending)
-        .into_iter()
+        .iter_events(CborRange { start, end }, SortOrder::Ascending)
         .map(|item| {
             let (_, v) = item.expect("Error while reading DB");
             minicbor::decode(&v).expect("Iterator item not an event.")

--- a/src/many-ledger/tests/iterator.rs
+++ b/src/many-ledger/tests/iterator.rs
@@ -1,7 +1,6 @@
 use many_identity::testing::identity;
 use many_identity::Address;
 use many_ledger::storage::LedgerStorage;
-use many_migration::MigrationConfig;
 use many_modules::events::{EventId, EventLog};
 use many_types::ledger::TokenAmount;
 use many_types::{CborRange, SortOrder};
@@ -26,7 +25,7 @@ fn setup() -> LedgerStorage {
         false,
         None,
         None,
-        MigrationConfig::default(),
+        None,
     )
     .unwrap();
 

--- a/src/many-ledger/tests/iterator.rs
+++ b/src/many-ledger/tests/iterator.rs
@@ -1,6 +1,7 @@
 use many_identity::testing::identity;
 use many_identity::Address;
 use many_ledger::storage::LedgerStorage;
+use many_migration::MigrationConfig;
 use many_modules::events::{EventId, EventLog};
 use many_types::ledger::TokenAmount;
 use many_types::{CborRange, SortOrder};
@@ -17,7 +18,7 @@ fn setup() -> LedgerStorage {
     let balances = BTreeMap::from([(id0, BTreeMap::from([(symbol0, TokenAmount::from(1000u16))]))]);
     let persistent_path = tempfile::tempdir().unwrap();
 
-    let mut storage = many_ledger::storage::LedgerStorage::new(
+    let mut storage = LedgerStorage::new(
         symbols,
         balances,
         persistent_path,
@@ -25,6 +26,7 @@ fn setup() -> LedgerStorage {
         false,
         None,
         None,
+        MigrationConfig::default(),
     )
     .unwrap();
 

--- a/src/many-ledger/tests/migration.rs
+++ b/src/many-ledger/tests/migration.rs
@@ -1,8 +1,12 @@
 pub mod common;
 use common::*;
 
+pub mod migration_;
+
 use many_identity::testing::identity;
-use many_ledger::migration::data::{ACCOUNT_TOTAL_COUNT_INDEX, NON_ZERO_ACCOUNT_TOTAL_COUNT_INDEX};
+use many_ledger::migration::data::{
+    ACCOUNT_COUNT_DATA_ATTRIBUTE, ACCOUNT_TOTAL_COUNT_INDEX, NON_ZERO_ACCOUNT_TOTAL_COUNT_INDEX,
+};
 use many_modules::{
     data::{DataGetInfoArgs, DataModuleBackend, DataQueryArgs},
     EmptyArg,
@@ -64,16 +68,7 @@ fn assert_metrics(harness: &Setup, expected_total: u32, expected_non_zero: u32) 
 #[test]
 fn migration() {
     // Setup starts with 2 accounts because of staging/ledger_state.json5
-    let content = r#"
-    [
-      {
-        "type": "Account Count Data Attribute",
-        "block_height": 2,
-        "issue": "https://github.com/liftedinit/many-framework/issues/190"
-      }
-    ]
-    "#;
-    let mut harness = Setup::new_with_migrations(true, content);
+    let mut harness = Setup::new_with_migrations(true, [(2, &ACCOUNT_COUNT_DATA_ATTRIBUTE)]);
     harness.set_balance(harness.id, 1_000_000, *MFX_SYMBOL);
 
     let (_height, a1) = harness.block(|h| {
@@ -126,16 +121,7 @@ fn migration() {
 
 #[test]
 fn migration_stress() {
-    let content = r#"
-    [
-      {
-        "type": "Account Count Data Attribute",
-        "block_height": 2,
-        "issue": "https://github.com/liftedinit/many-framework/issues/190"
-      }
-    ]
-    "#;
-    let mut harness = Setup::new_with_migrations(true, content);
+    let mut harness = Setup::new_with_migrations(true, [(2, &ACCOUNT_COUNT_DATA_ATTRIBUTE)]);
     harness.set_balance(harness.id, 1_000_000, *MFX_SYMBOL);
 
     let _ = harness.block(|h| {

--- a/src/many-ledger/tests/migration_/memo.rs
+++ b/src/many-ledger/tests/migration_/memo.rs
@@ -52,7 +52,6 @@ fn memo_migration_works() {
         .unwrap();
 
     assert_eq!(events.nb_events, 2);
-    eprintln!("last {:#?}", events.events.last());
     assert!(matches!(
         events.events.get(1).unwrap().content,
         EventInfo::AccountMultisigSubmit {
@@ -63,17 +62,23 @@ fn memo_migration_works() {
         },
     ));
 
-    for _ in 0..1 {
-        harness.block(|_| {});
-    }
-
-    // Wait 1 more block for the migration to run.
+    // Wait 1 block for the migration to run.
     harness.block(|_| {});
 
+    let events = harness
+        .module_impl
+        .list(ListArgs {
+            count: Some(10),
+            order: None,
+            filter: None,
+        })
+        .unwrap();
+
     // List events again.
-    assert_eq!(events.nb_events, 1);
+    assert_eq!(events.nb_events, 2);
+
     assert!(matches!(
-        events.events.first().unwrap().content,
+        events.events.last().unwrap().content,
         EventInfo::AccountMultisigSubmit {
             memo_: None,
             data_: None,

--- a/src/many-ledger/tests/migration_/memo.rs
+++ b/src/many-ledger/tests/migration_/memo.rs
@@ -2,16 +2,23 @@ use crate::common::{AccountType, Setup, MFX_SYMBOL};
 use many_identity::testing::identity;
 use many_identity::Address;
 use many_ledger::migration::memo::MEMO_MIGRATION;
-use many_modules::account::features::multisig::AccountMultisigModuleBackend;
+use many_modules::account::features::multisig;
 use many_modules::events::{EventInfo, EventsModuleBackend, ListArgs};
-use many_modules::{account, events, ledger};
+use many_modules::{events, ledger};
 use many_types::ledger::TokenAmount;
 use many_types::memo::MemoLegacy;
-use many_types::{Either, Memo};
+use many_types::Memo;
 
 #[test]
 fn memo_migration_works() {
-    fn make_multisig_transaction(h: &mut Setup, account_id: Address) {
+    fn make_multisig_transaction(
+        h: &mut Setup,
+        account_id: Address,
+        legacy_memo: Option<&str>,
+        legacy_data: Option<&str>,
+        memo_str: Option<&str>,
+        memo_data: Option<&str>,
+    ) -> Vec<u8> {
         let send_tx = events::AccountMultisigTransaction::Send(ledger::SendArgs {
             from: Some(account_id),
             to: identity(10),
@@ -19,120 +26,237 @@ fn memo_migration_works() {
             amount: TokenAmount::from(10_000u16),
         });
 
-        let tx = account::features::multisig::SubmitTransactionArgs {
+        let memo = match (memo_str, memo_data) {
+            (Some(s), Some(d)) => {
+                let mut m = Memo::try_from(s).unwrap();
+                m.push_bytes(d.as_bytes().to_vec()).unwrap();
+                Some(m)
+            }
+            (Some(s), _) => Some(Memo::try_from(s).unwrap()),
+            (_, Some(d)) => Some(Memo::try_from(d.as_bytes().to_vec()).unwrap()),
+            _ => None,
+        };
+
+        let tx = multisig::SubmitTransactionArgs {
             account: account_id,
-            memo_: Some(MemoLegacy::try_from("Legacy Memo".to_string()).unwrap()),
+            memo_: legacy_memo.map(|x| MemoLegacy::try_from(x.to_string()).unwrap()),
             transaction: Box::new(send_tx),
             threshold: None,
             timeout_in_secs: None,
             execute_automatically: None,
-            data_: Some(b"Legacy Data".to_vec().try_into().unwrap()),
+            data_: legacy_data.map(|x| x.as_bytes().to_vec().try_into().unwrap()),
             // This should be ignored as it would be backward incompatible
             // before the migration is active.
-            memo: Some(Memo::try_from("Memo").unwrap()),
+            memo,
         };
-        h.module_impl
-            .multisig_submit_transaction(&identity(1), tx)
-            .map(|x| x.token)
-            .unwrap();
+
+        multisig::AccountMultisigModuleBackend::multisig_submit_transaction(
+            &mut h.module_impl,
+            &identity(1),
+            tx,
+        )
+        .map(|x| x.token.to_vec())
+        .unwrap()
     }
 
-    fn check_events(
+    fn check_events<'a>(
         harness: &Setup,
-        expected_nb_events: u64,
-        assert_fn: fn((usize, events::EventLog)),
+        expected: impl IntoIterator<
+            Item = (
+                Option<&'a str>,
+                Option<&'a str>,
+                Option<&'a str>,
+                Option<&'a str>,
+            ),
+        >,
     ) {
         let events = harness.module_impl.list(ListArgs::default()).unwrap();
+        let mut all_events = events.events.into_iter().filter_map(|ev| {
+            if let EventInfo::AccountMultisigSubmit {
+                memo_, data_, memo, ..
+            } = ev.content
+            {
+                let memo_str = memo
+                    .as_ref()
+                    .and_then(|x| x.iter_str().next().map(|x| x.to_owned()));
+                let memo_data = memo
+                    .as_ref()
+                    .and_then(|x| x.iter_bytes().next().map(|x| x.to_owned()));
+                Some((
+                    memo_.map(|x| x.to_string()),
+                    data_.map(|x| x.as_bytes().to_vec()),
+                    memo_str,
+                    memo_data,
+                ))
+            } else {
+                None
+            }
+        });
+        let mut expected = expected
+            .into_iter()
+            .map(|(memo_, data_, memo_str, memo_data)| {
+                (
+                    memo_.map(|x| x.to_string()),
+                    data_.map(|x| x.as_bytes().to_vec()),
+                    memo_str.map(|x| x.to_string()),
+                    memo_data.map(|x| x.as_bytes().to_vec()),
+                )
+            });
 
-        assert_eq!(events.nb_events, expected_nb_events);
-        events.events.into_iter().enumerate().for_each(assert_fn);
+        while let (Some(actual), Some(expected)) = (all_events.next(), expected.next()) {
+            assert_eq!(actual, expected);
+        }
+        assert_eq!(
+            all_events.next(),
+            None,
+            "More actual elements than expected."
+        );
+        assert_eq!(expected.next(), None, "More expected elements than actual.");
+    }
+
+    fn check_info(
+        harness: &Setup,
+        token: &[u8],
+        legacy_memo: Option<&str>,
+        legacy_data: Option<&str>,
+        memo_str: Option<&str>,
+        memo_data: Option<&str>,
+    ) {
+        let (legacy_data, memo_data) =
+            (legacy_data.map(str::as_bytes), memo_data.map(str::as_bytes));
+        let info = multisig::AccountMultisigModuleBackend::multisig_info(
+            &harness.module_impl,
+            &Address::anonymous(),
+            multisig::InfoArgs {
+                token: token.to_vec().into(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(info.memo_.as_ref().map(|x| x.as_ref()), legacy_memo);
+        assert_eq!(info.data_.as_ref().map(|x| x.as_bytes()), legacy_data);
+        assert_eq!(
+            info.memo
+                .as_ref()
+                .and_then(|x| x.iter_str().next())
+                .map(|x| x.as_str()),
+            memo_str
+        );
+        assert_eq!(
+            info.memo.as_ref().and_then(|x| x.iter_bytes().next()),
+            memo_data
+        );
     }
 
     // Setup starts with 2 accounts because of staging/ledger_state.json5
-    let mut harness = Setup::new_with_migrations(true, [(5, &MEMO_MIGRATION)]);
+    let mut harness = Setup::new_with_migrations(true, [(8, &MEMO_MIGRATION)]);
     harness.set_balance(harness.id, 1_000_000, *MFX_SYMBOL);
     let (_, account_id) = harness.block(|h| {
         // Create an account.
         h.create_account_as_(identity(1), AccountType::Multisig)
     });
 
-    harness.block(|h| make_multisig_transaction(h, account_id));
-
-    check_events(&harness, 2, |(_, ev)| {
-        if let EventInfo::AccountMultisigSubmit {
-            memo_, data_, memo, ..
-        } = ev.content
-        {
-            assert_eq!(memo_.as_ref().map(|x| x.as_ref()), Some("Legacy Memo"));
-            assert_eq!(
-                data_.as_ref().map(|x| x.as_bytes()),
-                Some(b"Legacy Data".as_slice())
-            );
-            assert!(memo.is_none());
-        }
+    let (_, tx_id_1) = harness.block(|h| {
+        make_multisig_transaction(
+            h,
+            account_id,
+            Some("Legacy Memo1"),
+            Some("Legacy Data1"),
+            Some("Memo1"),
+            None,
+        )
+    });
+    let (_, tx_id_2) = harness.block(|h| {
+        make_multisig_transaction(
+            h,
+            account_id,
+            Some("Legacy Memo2"),
+            Some("Legacy Data2"),
+            None,
+            None,
+        )
+    });
+    let (_, tx_id_3) = harness.block(|h| {
+        make_multisig_transaction(h, account_id, None, None, Some("Memo3"), Some("Data3"))
     });
 
-    // Wait 2 block for the migration to run.
-    for _ in 0..2 {
+    // Wait 4 block for the migration to run.
+    // We created 4 blocks above; 1 for the account, 3 for multisig transactions.
+    for _i in 0..4 {
+        check_events(
+            &harness,
+            [
+                (Some("Legacy Memo1"), Some("Legacy Data1"), None, None),
+                (Some("Legacy Memo2"), Some("Legacy Data2"), None, None),
+                (None, None, None, None),
+            ],
+        );
+        check_info(
+            &harness,
+            &tx_id_1,
+            Some("Legacy Memo1"),
+            Some("Legacy Data1"),
+            None,
+            None,
+        );
+        check_info(
+            &harness,
+            &tx_id_2,
+            Some("Legacy Memo2"),
+            Some("Legacy Data2"),
+            None,
+            None,
+        );
+        check_info(&harness, &tx_id_3, None, None, None, None);
+
+        // Migration activates in the last loop.
         harness.block(|_| {});
-        check_events(&harness, 2, |(_, ev)| {
-            if let EventInfo::AccountMultisigSubmit {
-                memo_, data_, memo, ..
-            } = ev.content
-            {
-                assert_eq!(memo_.as_ref().map(|x| x.as_ref()), Some("Legacy Memo"));
-                assert_eq!(
-                    data_.as_ref().map(|x| x.as_bytes()),
-                    Some(b"Legacy Data".as_slice())
-                );
-                assert!(memo.is_none());
-            }
-        });
     }
 
-    // Wait 1 more block, migration activates here.
-    harness.block(|_| {});
-
-    check_events(&harness, 2, |(_, ev)| {
-        if let EventInfo::AccountMultisigSubmit {
-            memo_, data_, memo, ..
-        } = ev.content
-        {
-            assert!(memo_.is_none());
-            assert!(data_.is_none());
-            assert_eq!(
-                memo.unwrap(),
-                Memo::try_from_iter([
-                    Either::Left("Legacy Memo".to_string()),
-                    Either::Right(b"Legacy Data".to_vec())
-                ])
-                .unwrap()
-            );
-        }
-    });
+    check_events(
+        &harness,
+        [
+            (None, None, Some("Legacy Memo1"), Some("Legacy Data1")),
+            (None, None, Some("Legacy Memo2"), Some("Legacy Data2")),
+            (None, None, None, None),
+        ],
+    );
+    check_info(
+        &harness,
+        &tx_id_1,
+        None,
+        None,
+        Some("Legacy Memo1"),
+        Some("Legacy Data1"),
+    );
+    check_info(
+        &harness,
+        &tx_id_2,
+        None,
+        None,
+        Some("Legacy Memo2"),
+        Some("Legacy Data2"),
+    );
+    check_info(&harness, &tx_id_3, None, None, None, None);
 
     // Add a new event after migration is active.
-    harness.block(|h| make_multisig_transaction(h, account_id));
-
-    check_events(&harness, 3, |(idx, ev)| {
-        if let EventInfo::AccountMultisigSubmit {
-            memo_, data_, memo, ..
-        } = ev.content
-        {
-            assert!(memo_.is_none());
-            assert!(data_.is_none());
-
-            let memo = memo.unwrap();
-            assert!(
-                (memo == "Memo")
-                    || memo
-                        == Memo::try_from_iter([
-                            Either::Left("Legacy Memo".to_string()),
-                            Either::Right(b"Legacy Data".to_vec())
-                        ])
-                        .unwrap(),
-                "Memo does not match. {idx}: {memo:?}"
-            );
-        }
+    let (_, new_tx_id) = harness.block(|h| {
+        make_multisig_transaction(
+            h,
+            account_id,
+            Some("Legacy4"),
+            Some("Legacy4"),
+            Some("Memo4"),
+            Some("Data4"),
+        )
     });
+
+    check_info(
+        &harness,
+        &new_tx_id,
+        None,
+        None,
+        Some("Memo4"),
+        Some("Data4"),
+    );
 }

--- a/src/many-ledger/tests/migration_/memo.rs
+++ b/src/many-ledger/tests/migration_/memo.rs
@@ -1,23 +1,17 @@
 use crate::common::{AccountType, Setup, MFX_SYMBOL};
 use many_identity::testing::identity;
+use many_identity::Address;
 use many_ledger::migration::memo::MEMO_MIGRATION;
 use many_modules::account::features::multisig::AccountMultisigModuleBackend;
 use many_modules::events::{EventInfo, EventsModuleBackend, ListArgs};
 use many_modules::{account, events, ledger};
 use many_types::ledger::TokenAmount;
 use many_types::memo::MemoLegacy;
+use many_types::{Either, Memo};
 
 #[test]
 fn memo_migration_works() {
-    // Setup starts with 2 accounts because of staging/ledger_state.json5
-    let mut harness = Setup::new_with_migrations(true, [(3, &MEMO_MIGRATION, false)]);
-    harness.set_balance(harness.id, 1_000_000, *MFX_SYMBOL);
-    let (_, account_id) = harness.block(|h| {
-        // Create an account.
-        h.create_account_as_(identity(1), AccountType::Multisig)
-    });
-
-    let (_height, _) = harness.block(|h| {
+    fn make_multisig_transaction(h: &mut Setup, account_id: Address) {
         let send_tx = events::AccountMultisigTransaction::Send(ledger::SendArgs {
             from: Some(account_id),
             to: identity(10),
@@ -27,63 +21,100 @@ fn memo_migration_works() {
 
         let tx = account::features::multisig::SubmitTransactionArgs {
             account: account_id,
-            memo_: Some(MemoLegacy::try_from("Foo".to_string()).unwrap()),
+            memo_: Some(MemoLegacy::try_from("Legacy Memo".to_string()).unwrap()),
             transaction: Box::new(send_tx),
             threshold: None,
             timeout_in_secs: None,
             execute_automatically: None,
-            data_: Some(b"Bar".to_vec().try_into().unwrap()),
-            memo: None,
+            data_: Some(b"Legacy Data".to_vec().try_into().unwrap()),
+            // This should be ignored as it would be backward incompatible
+            // before the migration is active.
+            memo: Some(Memo::try_from("Memo").unwrap()),
         };
         h.module_impl
             .multisig_submit_transaction(&identity(1), tx)
             .map(|x| x.token)
             .unwrap();
+    }
+
+    fn check_events(
+        harness: &Setup,
+        expected_nb_events: u64,
+        assert_fn: fn((usize, events::EventLog)),
+    ) {
+        let events = harness.module_impl.list(ListArgs::default()).unwrap();
+
+        assert_eq!(events.nb_events, expected_nb_events);
+        events.events.into_iter().enumerate().for_each(assert_fn);
+    }
+
+    // Setup starts with 2 accounts because of staging/ledger_state.json5
+    let mut harness = Setup::new_with_migrations(true, [(3, &MEMO_MIGRATION, false)]);
+    harness.set_balance(harness.id, 1_000_000, *MFX_SYMBOL);
+    let (_, account_id) = harness.block(|h| {
+        // Create an account.
+        h.create_account_as_(identity(1), AccountType::Multisig)
     });
 
-    // List events.
-    let events = harness
-        .module_impl
-        .list(ListArgs {
-            count: Some(10),
-            order: None,
-            filter: None,
-        })
-        .unwrap();
+    harness.block(|h| make_multisig_transaction(h, account_id));
 
-    assert_eq!(events.nb_events, 2);
-    assert!(matches!(
-        events.events.get(1).unwrap().content,
-        EventInfo::AccountMultisigSubmit {
-            memo_: Some(_),
-            data_: Some(_),
-            memo: None,
-            ..
-        },
-    ));
+    check_events(&harness, 2, |(_, ev)| {
+        if let EventInfo::AccountMultisigSubmit {
+            memo_, data_, memo, ..
+        } = ev.content
+        {
+            assert_eq!(memo_.as_ref().map(|x| x.as_ref()), Some("Legacy Memo"));
+            assert_eq!(
+                data_.as_ref().map(|x| x.as_bytes()),
+                Some(b"Legacy Data".as_slice())
+            );
+            assert!(memo.is_none());
+        }
+    });
 
     // Wait 1 block for the migration to run.
     harness.block(|_| {});
 
-    let events = harness
-        .module_impl
-        .list(ListArgs {
-            count: Some(10),
-            order: None,
-            filter: None,
-        })
-        .unwrap();
+    check_events(&harness, 2, |(_, ev)| {
+        if let EventInfo::AccountMultisigSubmit {
+            memo_, data_, memo, ..
+        } = ev.content
+        {
+            assert!(memo_.is_none());
+            assert!(data_.is_none());
+            assert_eq!(
+                memo.unwrap(),
+                Memo::try_from_iter([
+                    Either::Left("Legacy Memo".to_string()),
+                    Either::Right(b"Legacy Data".to_vec())
+                ])
+                .unwrap()
+            );
+        }
+    });
 
-    // List events again.
-    assert_eq!(events.nb_events, 2);
+    // Add a new event after migration is active.
+    harness.block(|h| make_multisig_transaction(h, account_id));
 
-    assert!(matches!(
-        events.events.last().unwrap().content,
-        EventInfo::AccountMultisigSubmit {
-            memo_: None,
-            data_: None,
-            memo: Some(_),
-            ..
-        },
-    ));
+    check_events(&harness, 3, |(idx, ev)| {
+        if let EventInfo::AccountMultisigSubmit {
+            memo_, data_, memo, ..
+        } = ev.content
+        {
+            assert!(memo_.is_none());
+            assert!(data_.is_none());
+
+            let memo = memo.unwrap();
+            assert!(
+                (memo == "Memo")
+                    || memo
+                        == Memo::try_from_iter([
+                            Either::Left("Legacy Memo".to_string()),
+                            Either::Right(b"Legacy Data".to_vec())
+                        ])
+                        .unwrap(),
+                "Memo does not match. {idx}: {memo:?}"
+            );
+        }
+    });
 }

--- a/src/many-ledger/tests/migration_/memo.rs
+++ b/src/many-ledger/tests/migration_/memo.rs
@@ -1,0 +1,84 @@
+use crate::common::{AccountType, Setup, MFX_SYMBOL};
+use many_identity::testing::identity;
+use many_ledger::migration::memo::MEMO_MIGRATION;
+use many_modules::account::features::multisig::AccountMultisigModuleBackend;
+use many_modules::events::{EventInfo, EventsModuleBackend, ListArgs};
+use many_modules::{account, events, ledger};
+use many_types::ledger::TokenAmount;
+use many_types::memo::MemoLegacy;
+
+#[test]
+fn memo_migration_works() {
+    // Setup starts with 2 accounts because of staging/ledger_state.json5
+    let mut harness = Setup::new_with_migrations(true, [(3, &MEMO_MIGRATION, false)]);
+    harness.set_balance(harness.id, 1_000_000, *MFX_SYMBOL);
+    let (_, account_id) = harness.block(|h| {
+        // Create an account.
+        h.create_account_as_(identity(1), AccountType::Multisig)
+    });
+
+    let (_height, _) = harness.block(|h| {
+        let send_tx = events::AccountMultisigTransaction::Send(ledger::SendArgs {
+            from: Some(account_id),
+            to: identity(10),
+            symbol: *MFX_SYMBOL,
+            amount: TokenAmount::from(10_000u16),
+        });
+
+        let tx = account::features::multisig::SubmitTransactionArgs {
+            account: account_id,
+            memo_: Some(MemoLegacy::try_from("Foo".to_string()).unwrap()),
+            transaction: Box::new(send_tx),
+            threshold: None,
+            timeout_in_secs: None,
+            execute_automatically: None,
+            data_: Some(b"Bar".to_vec().try_into().unwrap()),
+            memo: None,
+        };
+        h.module_impl
+            .multisig_submit_transaction(&identity(1), tx)
+            .map(|x| x.token)
+            .unwrap();
+    });
+
+    // List events.
+    let events = harness
+        .module_impl
+        .list(ListArgs {
+            count: Some(10),
+            order: None,
+            filter: None,
+        })
+        .unwrap();
+
+    assert_eq!(events.nb_events, 2);
+    eprintln!("last {:#?}", events.events.last());
+    assert!(matches!(
+        events.events.get(1).unwrap().content,
+        EventInfo::AccountMultisigSubmit {
+            memo_: Some(_),
+            data_: Some(_),
+            memo: None,
+            ..
+        },
+    ));
+
+    for _ in 0..1 {
+        harness.block(|_| {});
+    }
+
+    // Wait 1 more block for the migration to run.
+    harness.block(|_| {});
+
+    // List events again.
+    assert_eq!(events.nb_events, 1);
+    assert!(matches!(
+        events.events.first().unwrap().content,
+        EventInfo::AccountMultisigSubmit {
+            memo_: None,
+            data_: None,
+            memo: Some(_),
+            ..
+        },
+    ));
+}

--- a/src/many-ledger/tests/migration_/mod.rs
+++ b/src/many-ledger/tests/migration_/mod.rs
@@ -1,0 +1,1 @@
+mod memo;

--- a/src/many-ledger/tests/multisig.rs
+++ b/src/many-ledger/tests/multisig.rs
@@ -5,7 +5,7 @@ use many_error::ManyError;
 use many_identity::testing::identity;
 use many_identity::Address;
 use many_ledger::module::LedgerModuleImpl;
-use many_modules::account::features::multisig::{AccountMultisigModuleBackend, Memo};
+use many_modules::account::features::multisig::AccountMultisigModuleBackend;
 use many_modules::account::features::{multisig, TryCreateFeature};
 use many_modules::{account, events, ledger};
 use many_types::ledger::TokenAmount;
@@ -50,12 +50,13 @@ fn submit_args(
 ) -> multisig::SubmitTransactionArgs {
     multisig::SubmitTransactionArgs {
         account: account_id,
-        memo: Some(Memo::try_from("Foo".to_string()).unwrap()),
+        memo: None,
         transaction: Box::new(transaction),
         threshold: None,
         timeout_in_secs: None,
         execute_automatically,
-        data: None,
+        data_: None,
+        memo_: None,
     }
 }
 
@@ -126,7 +127,8 @@ proptest! {
         assert!(get_approbation(&tx_info, &id));
         assert_eq!(tx_info.threshold, 3);
         assert!(!tx_info.execute_automatically);
-        assert_eq!(tx_info.data, submit_args.data);
+        assert_eq!(tx_info.data_, submit_args.data_);
+        assert_eq!(tx_info.memo_, submit_args.memo_);
     }
 
     #[test]
@@ -677,7 +679,8 @@ fn recursive_multisig() {
             threshold: None,
             timeout_in_secs: None,
             execute_automatically: Some(false),
-            data: None,
+            data_: None,
+            memo_: None,
         },
     );
 
@@ -713,7 +716,7 @@ fn recursive_multisig() {
     assert!(response.data.is_err());
     assert_many_err(
         response.data,
-        ManyError::attribute_not_found(account::features::multisig::MultisigAccountFeature::ID),
+        ManyError::attribute_not_found(multisig::MultisigAccountFeature::ID),
     );
 
     // Let's make acc2 a Multisig account
@@ -736,7 +739,8 @@ fn recursive_multisig() {
             threshold: None,
             timeout_in_secs: None,
             execute_automatically: None,
-            data: None,
+            data_: None,
+            memo_: None,
         },
     );
 

--- a/src/many-ledger/tests/storage.rs
+++ b/src/many-ledger/tests/storage.rs
@@ -1,7 +1,6 @@
 use many_identity::testing::identity;
 use many_identity::Address;
 use many_ledger::{module::LedgerModuleImpl, storage::LedgerStorage};
-use many_migration::MigrationConfig;
 use many_modules::account::features::FeatureInfo;
 use many_modules::account::AccountModuleBackend;
 use many_modules::ledger::LedgerModuleBackend;
@@ -27,7 +26,7 @@ fn load() {
             false,
             None,
             None,
-            MigrationConfig::default(),
+            None,
         );
         let mut module_impl = LedgerModuleImpl::load(None, path.clone(), false).unwrap();
 

--- a/src/many-ledger/tests/storage.rs
+++ b/src/many-ledger/tests/storage.rs
@@ -1,6 +1,7 @@
 use many_identity::testing::identity;
 use many_identity::Address;
 use many_ledger::{module::LedgerModuleImpl, storage::LedgerStorage};
+use many_migration::MigrationConfig;
 use many_modules::account::features::FeatureInfo;
 use many_modules::account::AccountModuleBackend;
 use many_modules::ledger::LedgerModuleBackend;
@@ -26,6 +27,7 @@ fn load() {
             false,
             None,
             None,
+            MigrationConfig::default(),
         );
         let mut module_impl = LedgerModuleImpl::load(None, path.clone(), false).unwrap();
 

--- a/tests/e2e/ledger/migrations.bats
+++ b/tests/e2e/ledger/migrations.bats
@@ -108,7 +108,7 @@ function teardown() {
       }
     ]' > "$BATS_TEST_ROOTDIR/migrations.json"
 
-    start_ledger --background_output="Unsupported migration type" \
+    start_ledger --background_output="Unsupported migration 'Foobar'" \
         --pem "$(pem 0)" \
         "--migrations-config=$BATS_TEST_ROOTDIR/migrations.json"
 }

--- a/tests/e2e/ledger/migrations.bats
+++ b/tests/e2e/ledger/migrations.bats
@@ -133,7 +133,7 @@ function teardown() {
       }
     ]' > "$BATS_TEST_ROOTDIR/migrations.json"
 
-    start_ledger --background_output="block_height: 40.*status: Disabled" \
+    start_ledger --background_output="block_height: 40, disabled: true" \
         --pem "$(pem 0)" \
         "--migrations-config=$BATS_TEST_ROOTDIR/migrations.json"
 }

--- a/tests/e2e/ledger/migrations.bats
+++ b/tests/e2e/ledger/migrations.bats
@@ -23,7 +23,7 @@ function teardown() {
 
 @test "$SUITE: Load migrations" {
     echo '
-    [
+    { "migrations": [
       {
         "name": "Account Count Data Attribute",
         "block_height": 20,
@@ -39,7 +39,7 @@ function teardown() {
         "block_height": 0,
         "disabled": true
       }
-    ]' > "$BATS_TEST_ROOTDIR/migrations.json"
+    ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 
     start_ledger --pem "$(pem 0)" \
         "--migrations-config=$BATS_TEST_ROOTDIR/migrations.json"
@@ -47,7 +47,7 @@ function teardown() {
 
 @test "$SUITE: Missing migration (bad length)" {
     echo '
-    [
+    { "migrations": [
       {
         "name": "Dummy Hotfix",
         "block_height": 0,
@@ -58,7 +58,7 @@ function teardown() {
         "block_height": 0,
         "disabled": true
       }
-    ]' > "$BATS_TEST_ROOTDIR/migrations.json"
+    ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 
     start_ledger --background_output="Migration configuration file is missing migration\(s\)"\
         --pem "$(pem 0)" \
@@ -67,7 +67,7 @@ function teardown() {
 
 @test "$SUITE: Missing migration (right length, duplicate)" {
     echo '
-    [
+    { "migrations": [
       {
         "name": "Dummy Hotfix",
         "block_height": 20
@@ -82,7 +82,7 @@ function teardown() {
         "block_height": 0,
         "disabled": true
       }
-    ]' > "$BATS_TEST_ROOTDIR/migrations.json"
+    ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 
     start_ledger --background_output="Migration configuration file is missing" \
         --pem "$(pem 0)" \
@@ -91,7 +91,7 @@ function teardown() {
 
 @test "$SUITE: Unsupported migration type" {
     echo '
-    [
+    { "migrations": [
       {
         "name": "Foobar",
         "block_height": 20
@@ -106,7 +106,7 @@ function teardown() {
         "block_height": 0,
         "disabled": true
       }
-    ]' > "$BATS_TEST_ROOTDIR/migrations.json"
+    ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 
     start_ledger --background_output="Unsupported migration 'Foobar'" \
         --pem "$(pem 0)" \
@@ -115,7 +115,7 @@ function teardown() {
 
 @test "$SUITE: Can disable" {
     echo '
-    [
+    { "migrations": [
       {
         "name": "Account Count Data Attribute",
         "block_height": 20,
@@ -131,7 +131,7 @@ function teardown() {
         "block_height": 40,
         "disabled": true
       }
-    ]' > "$BATS_TEST_ROOTDIR/migrations.json"
+    ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 
     start_ledger --background_output="block_height: 40, disabled: true" \
         --pem "$(pem 0)" \

--- a/tests/e2e/ledger/migrations.bats
+++ b/tests/e2e/ledger/migrations.bats
@@ -38,6 +38,11 @@ function teardown() {
         "name": "Block 9400",
         "block_height": 0,
         "disabled": true
+      },
+      {
+        "name": "Memo Migration",
+        "block_height": 0,
+        "disabled": true
       }
     ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 
@@ -57,10 +62,15 @@ function teardown() {
         "name": "Block 9400",
         "block_height": 0,
         "disabled": true
+      },
+      {
+        "name": "Memo Migration",
+        "block_height": 0,
+        "disabled": true
       }
     ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 
-    start_ledger --background_output="Migration configuration file is missing migration\(s\)"\
+    start_ledger --background_output="Migration Config is missing migration"\
         --pem "$(pem 0)" \
         "--migrations-config=$BATS_TEST_ROOTDIR/migrations.json"
 }
@@ -81,10 +91,15 @@ function teardown() {
         "name": "Block 9400",
         "block_height": 0,
         "disabled": true
+      },
+      {
+        "name": "Memo Migration",
+        "block_height": 0,
+        "disabled": true
       }
     ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 
-    start_ledger --background_output="Migration configuration file is missing" \
+    start_ledger --background_output="Migration Config is missing migration" \
         --pem "$(pem 0)" \
         "--migrations-config=$BATS_TEST_ROOTDIR/migrations.json"
 }
@@ -103,6 +118,11 @@ function teardown() {
       },
       {
         "name": "Block 9400",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Memo Migration",
         "block_height": 0,
         "disabled": true
       }
@@ -129,6 +149,11 @@ function teardown() {
       {
         "name": "Block 9400",
         "block_height": 40,
+        "disabled": true
+      },
+      {
+        "name": "Memo Migration",
+        "block_height": 0,
         "disabled": true
       }
     ] }' > "$BATS_TEST_ROOTDIR/migrations.json"

--- a/tests/e2e/ledger/migrations.bats
+++ b/tests/e2e/ledger/migrations.bats
@@ -25,19 +25,19 @@ function teardown() {
     echo '
     [
       {
-        "type": "Account Count Data Attribute",
+        "name": "Account Count Data Attribute",
         "block_height": 20,
         "issue": "https://github.com/liftedinit/many-framework/issues/190"
       },
       {
-        "type": "Dummy Hotfix",
+        "name": "Dummy Hotfix",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       },
       {
-        "type": "Block 9400",
+        "name": "Block 9400",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       }
     ]' > "$BATS_TEST_ROOTDIR/migrations.json"
 
@@ -49,14 +49,14 @@ function teardown() {
     echo '
     [
       {
-        "type": "Dummy Hotfix",
+        "name": "Dummy Hotfix",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       },
       {
-        "type": "Block 9400",
+        "name": "Block 9400",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       }
     ]' > "$BATS_TEST_ROOTDIR/migrations.json"
 
@@ -69,18 +69,18 @@ function teardown() {
     echo '
     [
       {
-        "type": "Dummy Hotfix",
+        "name": "Dummy Hotfix",
         "block_height": 20
       },
       {
-        "type": "Dummy Hotfix",
+        "name": "Dummy Hotfix",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       },
       {
-        "type": "Block 9400",
+        "name": "Block 9400",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       }
     ]' > "$BATS_TEST_ROOTDIR/migrations.json"
 
@@ -93,18 +93,18 @@ function teardown() {
     echo '
     [
       {
-        "type": "Foobar",
+        "name": "Foobar",
         "block_height": 20
       },
       {
-        "type": "Dummy Hotfix",
+        "name": "Dummy Hotfix",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       },
       {
-        "type": "Block 9400",
+        "name": "Block 9400",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       }
     ]' > "$BATS_TEST_ROOTDIR/migrations.json"
 
@@ -117,19 +117,19 @@ function teardown() {
     echo '
     [
       {
-        "type": "Account Count Data Attribute",
+        "name": "Account Count Data Attribute",
         "block_height": 20,
         "issue": "https://github.com/liftedinit/many-framework/issues/190"
       },
       {
-        "type": "Dummy Hotfix",
+        "name": "Dummy Hotfix",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       },
       {
-        "type": "Block 9400",
+        "name": "Block 9400",
         "block_height": 40,
-        "status": "Disabled"
+        "disabled": true
       }
     ]' > "$BATS_TEST_ROOTDIR/migrations.json"
 

--- a/tests/resiliency/ledger/account_count_migration.bats
+++ b/tests/resiliency/ledger/account_count_migration.bats
@@ -23,6 +23,11 @@ function setup() {
         "name": "Block 9400",
         "block_height": 0,
         "disabled": true
+      },
+      {
+        "name": "Memo Migration",
+        "block_height": 0,
+        "disabled": true
       }
     ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 

--- a/tests/resiliency/ledger/account_count_migration.bats
+++ b/tests/resiliency/ledger/account_count_migration.bats
@@ -10,19 +10,19 @@ function setup() {
     echo '
     [
       {
-        "type": "Account Count Data Attribute",
+        "name": "Account Count Data Attribute",
         "block_height": 20,
         "issue": "https://github.com/liftedinit/many-framework/issues/190"
       },
       {
-        "type": "Dummy Hotfix",
+        "name": "Dummy Hotfix",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       },
       {
-        "type": "Block 9400",
+        "name": "Block 9400",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       }
     ]' > "$BATS_TEST_ROOTDIR/migrations.json"
 

--- a/tests/resiliency/ledger/account_count_migration.bats
+++ b/tests/resiliency/ledger/account_count_migration.bats
@@ -8,7 +8,7 @@ function setup() {
     mkdir "$BATS_TEST_ROOTDIR"
 
     echo '
-    [
+    { "migrations": [
       {
         "name": "Account Count Data Attribute",
         "block_height": 20,
@@ -24,7 +24,7 @@ function setup() {
         "block_height": 0,
         "disabled": true
       }
-    ]' > "$BATS_TEST_ROOTDIR/migrations.json"
+    ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
 
     (
       cd "$GIT_ROOT/docker/e2e/" || exit

--- a/tests/resiliency/ledger/dummy_migration.bats
+++ b/tests/resiliency/ledger/dummy_migration.bats
@@ -10,19 +10,19 @@ function setup() {
     echo '
     [
       {
-        "type": "Dummy Hotfix",
+        "name": "Dummy Hotfix",
         "block_height": 20
       },
       {
-        "type": "Account Count Data Attribute",
+        "name": "Account Count Data Attribute",
         "block_height": 0,
         "issue": "https://github.com/liftedinit/many-framework/issues/190",
-        "status": "Disabled"
+        "disabled": true
       },
       {
-        "type": "Block 9400",
+        "name": "Block 9400",
         "block_height": 0,
-        "status": "Disabled"
+        "disabled": true
       }
     ]' > "$BATS_TEST_ROOTDIR/migration.json"
     (

--- a/tests/resiliency/ledger/dummy_migration.bats
+++ b/tests/resiliency/ledger/dummy_migration.bats
@@ -23,6 +23,11 @@ function setup() {
         "name": "Block 9400",
         "block_height": 0,
         "disabled": true
+      },
+      {
+        "name": "Memo Migration",
+        "block_height": 0,
+        "disabled": true
       }
     ] }' > "$BATS_TEST_ROOTDIR/migration.json"
     (

--- a/tests/resiliency/ledger/dummy_migration.bats
+++ b/tests/resiliency/ledger/dummy_migration.bats
@@ -8,7 +8,7 @@ function setup() {
     mkdir "$BATS_TEST_ROOTDIR"
 
     echo '
-    [
+    { "migrations": [
       {
         "name": "Dummy Hotfix",
         "block_height": 20
@@ -24,7 +24,7 @@ function setup() {
         "block_height": 0,
         "disabled": true
       }
-    ]' > "$BATS_TEST_ROOTDIR/migration.json"
+    ] }' > "$BATS_TEST_ROOTDIR/migration.json"
     (
       cd "$GIT_ROOT/docker/e2e/" || exit
       make -f $MAKEFILE clean

--- a/tests/resiliency/ledger/memo_migration.bats
+++ b/tests/resiliency/ledger/memo_migration.bats
@@ -79,7 +79,6 @@ function teardown() {
     assert_output --regexp "3:.*Legacy_Memo"
     refute_output --partial "New_Memo"
 
-    # Wait for block 30
     wait_for_block 30
 
     run many_message --pem=1 events.list "{}"

--- a/tests/resiliency/ledger/memo_migration.bats
+++ b/tests/resiliency/ledger/memo_migration.bats
@@ -1,0 +1,81 @@
+GIT_ROOT="$BATS_TEST_DIRNAME/../../../"
+MAKEFILE="Makefile.ledger"
+
+load '../../test_helper/load'
+load '../../test_helper/ledger'
+
+function setup() {
+    mkdir "$BATS_TEST_ROOTDIR"
+
+    echo '
+    { "migrations": [
+      {
+        "name": "Account Count Data Attribute",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Dummy Hotfix",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Block 9400",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Memo Migration",
+        "block_height": 5
+      }
+    ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
+
+    (
+      cd "$GIT_ROOT/docker/e2e/" || exit
+      make -f $MAKEFILE clean
+      make -f $MAKEFILE $(ciopt start-nodes-dettached) \
+          ABCI_TAG=$(img_tag) \
+          LEDGER_TAG=$(img_tag) \
+          ID_WITH_BALANCES="$(identity 1):1000000" \
+          MIGRATIONS="$BATS_TEST_ROOTDIR/migrations.json" || {
+        echo Could not start nodes... >&3
+        exit 1
+      }
+    ) > /dev/null
+
+    # Give time to the servers to start.
+    sleep 30
+    timeout 30s bash <<EOT
+    while ! many message --server http://localhost:8000 status; do
+      sleep 1
+    done >/dev/null
+EOT
+}
+
+function teardown() {
+    (
+      cd "$GIT_ROOT/docker/e2e/" || exit 1
+      make -f $MAKEFILE stop-nodes
+    ) 2> /dev/null
+
+    # Fix for BATS verbose run/test output gathering
+    cd "$GIT_ROOT/tests/resiliency/ledger" || exit 1
+}
+
+@test "$SUITE: Account Count" {
+    check_consistency --pem=1 --balance=1000000 --id="$(identity 1)" 8000 8001 8002 8003
+
+    account_id=$(account_create --pem=1 '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')
+    call_ledger --pem=1 --port=8000 multisig \
+        submit --legacy-memo="Legacy Memo" --memo="New Memo" "$account_id" \
+        send "$(identity 2)" 1000 MFX
+
+    run many_message events.list "{}"
+
+    # Wait for some blocks to be built
+    sleep 15
+
+    run many_message events.list "{}"
+    assert_output --partial "New Memo"
+    assert_output --partial "Legacy Memo"
+}

--- a/tests/resiliency/ledger/memo_migration.bats
+++ b/tests/resiliency/ledger/memo_migration.bats
@@ -68,10 +68,10 @@ function teardown() {
 
     check_consistency --pem=1 --balance=1000000 --id="$(identity 1)" 8000 8001 8002 8003
 
-    call_ledger --pem=1 --port=8000 send "$account_id" 1000000 MFX
     account_id="$(account_create --pem=1 '{ 1: { "'"$(identity 2)"'": ["canMultisigApprove"] }, 2: [[1, { 0: 2 }]] }')"
+    call_ledger --pem=1 --port=8000 send "$account_id" 1000000 MFX
 
-    call_ledger --pem=1 --port=8000 -vv multisig \
+    call_ledger --pem=1 --port=8000 multisig \
         submit --legacy-memo="Legacy_Memo" --memo="New_Memo" "$account_id" \
         send "$(identity 2)" 1000 MFX
 
@@ -87,7 +87,7 @@ function teardown() {
     assert_output --partial "10: [\"Legacy_Memo\"]"
     refute_output --partial "New_Memo"
 
-    call_ledger --pem=1 --port=8000 -vv multisig \
+    call_ledger --pem=1 --port=8000 multisig \
         submit --legacy-memo="Legacy_Memo2" --memo="New_Memo2" "$account_id" \
         send "$(identity 2)" 1000 MFX
 

--- a/tests/resiliency/ledger/memo_migration.bats
+++ b/tests/resiliency/ledger/memo_migration.bats
@@ -64,7 +64,8 @@ function teardown() {
 
 @test "$SUITE: Memo Migration" {
     local account_id
-    local tx_id
+    local tx_id_1
+    local tx_id_2
 
     check_consistency --pem=1 --balance=1000000 --id="$(identity 1)" 8000 8001 8002 8003
 
@@ -74,10 +75,16 @@ function teardown() {
     call_ledger --pem=1 --port=8000 multisig \
         submit --legacy-memo="Legacy_Memo" --memo="New_Memo" "$account_id" \
         send "$(identity 2)" 1000 MFX
+    tx_id_1=$(echo $output | grep "Transaction Token:" | grep -o "[0-9a-f]*$")
 
     run many_message --pem=1 events.list "{}"
     assert_output --regexp "3:.*Legacy_Memo"
     refute_output --partial "New_Memo"
+
+    call_ledger --port=8000 multisig info $tx_id_1
+    assert_output --partial "memo_: Some"
+    assert_output --partial "data_: None"
+    assert_output --partial "memo: None"
 
     wait_for_block 30
 
@@ -89,8 +96,19 @@ function teardown() {
     call_ledger --pem=1 --port=8000 multisig \
         submit --legacy-memo="Legacy_Memo2" --memo="New_Memo2" "$account_id" \
         send "$(identity 2)" 1000 MFX
+    tx_id_2=$(echo $output | grep "Transaction Token:" | grep -o "[0-9a-f]*$")
 
     run many_message --pem=1 events.list "{}"
     assert_output --regexp "10:.*New_Memo2"
     refute_output --partial "Legacy_Memo2"
+
+    call_ledger --port=8000 multisig info $tx_id_1
+    assert_output --partial "memo_: None"
+    assert_output --partial "data_: None"
+    assert_output --partial "memo: Some"
+
+    call_ledger --port=8000 multisig info $tx_id_2
+    assert_output --partial "memo_: None"
+    assert_output --partial "data_: None"
+    assert_output --partial "memo: Some"
 }

--- a/tests/test_helper/many.bash
+++ b/tests/test_helper/many.bash
@@ -44,3 +44,14 @@ function identity_hex() {
 function account() {
     command many id mahukzwuwgt3porn6q4vq4xu3mwy5gyskhouryzbscq7wb2iow "$1"
 }
+
+function wait_for_block() {
+    local block
+    local current
+    block="$1"
+    current=$(many message --server http://localhost:8000/ blockchain.info | grep -oE '1: \d+' | colrm 1 3)
+    while [ "$current" -lt "$block" ]; do
+      sleep 1
+      current=$(many message --server http://localhost:8000/ blockchain.info | grep -oE '1: \d+' | colrm 1 3)
+    done >/dev/null
+}

--- a/tests/test_helper/many.bash
+++ b/tests/test_helper/many.bash
@@ -48,10 +48,12 @@ function account() {
 function wait_for_block() {
     local block
     local current
-    block="$1"
-    current=$(many message --server http://localhost:8000/ blockchain.info | grep -oE '1: \d+' | colrm 1 3)
+    block=$1
+    # Using [0-9] instead of \d for grep 3.8
+    # https://salsa.debian.org/debian/grep/-/blob/debian/master/NEWS
+    current=$(many message --server http://localhost:8000/ blockchain.info | grep -oE '1: [0-9]+' | colrm 1 3)
     while [ "$current" -lt "$block" ]; do
       sleep 1
-      current=$(many message --server http://localhost:8000/ blockchain.info | grep -oE '1: \d+' | colrm 1 3)
+      current=$(many message --server http://localhost:8000/ blockchain.info | grep -oE '1: [0-9]+' | colrm 1 3)
     done >/dev/null
 }


### PR DESCRIPTION
This follows the many-rs PR https://github.com/liftedinit/many-rs/pull/201 and the specification latest master and its follow up PR https://github.com/many-protocol/specification/pull/58 which includes burnt fields (to add new fields instead of re-typing old ones).
