### PR TITLE
Fix docker nightly publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,6 +446,9 @@ workflows:
         - equal: [ "Nightly Docker and Resiliency Tests", << pipeline.schedule.name >> ]
     jobs:
       - publish_nightly_docker:
+          pre-steps:
+            - install-deps:
+                os: linux2204
           context:
             - DOCKER_CREDS
             - CACHE


### PR DESCRIPTION
libusb-1.0 is required since recent `many-rs` changes