### PR TITLE
Upgrade Bazel rules_rust to 0.15

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 # Taken from the Bazel `rules_rust` Github repository
+build --@rules_rust//rust/toolchain/channel=nightly
 
 # Enable rustfmt for all targets in the workspace
 build:rustfmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -3,27 +3,12 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
  "opaque-debug",
@@ -52,6 +37,18 @@ name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ascii"
@@ -96,7 +93,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.1",
+ "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror",
@@ -226,23 +223,12 @@ dependencies = [
  "async-lock",
  "autocfg",
  "blocking",
- "cfg-if",
+ "cfg-if 1.0.0",
  "event-listener",
  "futures-lite",
  "libc",
  "signal-hook",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -287,14 +273,14 @@ checksum = "d06c690e5e2800f70c0cf8773a9fe7680d66e719dae9b4cabedd13ef4885d056"
 dependencies = [
  "base64 0.13.1",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "core-foundation",
  "devd-rs",
  "libc",
  "libudev",
  "log",
  "memoffset",
- "nom 7.1.1",
+ "nom",
  "openssl",
  "openssl-sys",
  "rand 0.8.5",
@@ -318,21 +304,6 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
-
-[[package]]
-name = "backtrace"
-version = "0.3.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base32"
@@ -393,6 +364,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+]
+
+[[package]]
+name = "bip39-dict"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b74d395d6b577a1e3c1348545cef70a418281c83abbe50f5662ae4d4abf6d8"
+dependencies = [
+ "cryptoxide",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +411,21 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake3"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 0.1.10",
+ "constant_time_eq",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -463,31 +477,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
-
-[[package]]
-name = "bytecount"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
@@ -506,24 +499,19 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
-name = "cbor-diag"
-version = "0.1.11"
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2644c5bb01d8328b218301180b84ccc6f7fce031d50e30917b07ae762a185b7b"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
 dependencies = [
- "bs58",
- "chrono",
- "data-encoding",
- "half 2.1.0",
- "nom 5.1.2",
- "num-bigint",
- "num-rational",
- "num-traits",
- "separator",
- "url",
- "uuid",
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -531,6 +519,9 @@ name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cexpr"
@@ -538,8 +529,14 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.1",
+ "nom",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -566,8 +563,7 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -577,14 +573,12 @@ dependencies = [
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
 dependencies = [
  "ciborium-io",
  "half 1.8.2",
@@ -648,7 +642,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -665,6 +659,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "compact_jwt"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,7 +683,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -700,7 +705,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "terminal_size",
- "unicode-width",
  "winapi",
 ]
 
@@ -715,6 +719,12 @@ name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -766,7 +776,7 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -799,6 +809,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
@@ -825,9 +845,24 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4895bb04269df9a14f2692c6499dc2769e9a93caa33ef37c4df134f76956d2"
 dependencies = [
- "bindgen",
+ "bindgen 0.59.2",
  "libloading",
  "target-lexicon",
+]
+
+[[package]]
+name = "cryptoxide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129eabb7b0b78644a3a7e7cf220714aba47463bb281f69fa7a71ca5d12564cca"
+
+[[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
 ]
 
 [[package]]
@@ -841,61 +876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cucumber"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399fa7fc41ab7163fc49d5c2613b582b04bbf2d5342fcb1946fc1efd5b71193c"
-dependencies = [
- "async-trait",
- "atty",
- "clap 3.2.23",
- "console",
- "cucumber-codegen",
- "cucumber-expressions",
- "derive_more",
- "either",
- "futures",
- "gherkin",
- "globwalk",
- "inventory",
- "itertools",
- "linked-hash-map",
- "once_cell",
- "regex",
- "sealed 0.4.0",
-]
-
-[[package]]
-name = "cucumber-codegen"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6f939adacd640286fb794ec392c068367991795db4c2c9112b748fb4fbf04f"
-dependencies = [
- "cucumber-expressions",
- "inflections",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "syn",
- "synthez",
-]
-
-[[package]]
-name = "cucumber-expressions"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40d2fdf5e1bb4ae7e6b25c97bf9b9d249a02243fc0fbd91075592b5f00a3bc1"
-dependencies = [
- "derive_more",
- "either",
- "nom 7.1.1",
- "nom_locate",
- "regex",
- "regex-syntax",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +885,19 @@ dependencies = [
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
  "zeroize",
 ]
 
@@ -1017,7 +1010,7 @@ checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom 7.1.1",
+ "nom",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -1097,31 +1090,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "devd-rs"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9313f104b590510b46fc01c0a324fc76505c13871454d3c48490468d04c8d395"
 dependencies = [
  "libc",
- "nom 7.1.1",
+ "nom",
 ]
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1155,12 +1131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,12 +1143,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed"
+version = "0.2.2-alpha.0"
+source = "git+https://github.com/nomic-io/ed?rev=dd28e9f9e7c97827dde943ee8decfcdf25b3cc83#dd28e9f9e7c97827dde943ee8decfcdf25b3cc83"
+dependencies = [
+ "ed-derive",
+ "thiserror",
+]
+
+[[package]]
+name = "ed-derive"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06a91d774f4b861acaa791bc6165e66d72d3a5d1aa85fc8c0956f5580f863161"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ed25519"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "signature",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758e2a0cd8a6cdf483e1d369e7d081647e00b88d8953e34d8f2cbba05ae28368"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.9.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -1229,7 +1232,27 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1246,10 +1269,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
 
 [[package]]
 name = "fastrand"
@@ -1283,12 +1325,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
+name = "flex-error"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
- "num-traits",
+ "eyre",
+ "paste",
 ]
 
 [[package]]
@@ -1320,12 +1363,6 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -1447,7 +1484,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1458,26 +1495,23 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "gherkin"
-version = "0.12.0"
+name = "getset"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ab17bb865b7c4fbca5133801229aeb127e254a47c29fd26968195fce9458ab"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
 dependencies = [
- "heck 0.3.3",
- "peg",
+ "proc-macro-error",
+ "proc-macro2",
  "quote",
- "serde",
- "serde_json",
  "syn",
- "textwrap 0.12.1",
- "thiserror",
- "typed-builder",
 ]
 
 [[package]]
@@ -1492,40 +1526,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.26.2"
+name = "git2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "globset"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
-dependencies = [
- "aho-corasick",
- "bstr",
- "fnv",
- "log",
- "regex",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
-dependencies = [
- "bitflags",
- "ignore",
- "walkdir",
-]
 
 [[package]]
 name = "group"
@@ -1579,12 +1596,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "headers"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "unicode-segmentation",
+ "base64 0.13.1",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -1607,6 +1640,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hidapi"
@@ -1626,7 +1662,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.11.1",
  "digest 0.9.0",
 ]
 
@@ -1659,6 +1695,26 @@ dependencies = [
  "bytes",
  "http",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http_proxy"
+version = "0.1.0"
+dependencies = [
+ "clap 3.2.23",
+ "hex",
+ "many-client",
+ "many-identity",
+ "many-identity-dsa",
+ "many-kvstore",
+ "many-modules",
+ "minicbor",
+ "new_mime_guess",
+ "syslog-tracing",
+ "tiny_http",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1704,6 +1760,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-proxy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,22 +1826,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "ignore"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+name = "idstore-export"
+version = "0.1.0"
 dependencies = [
- "crossbeam-utils",
- "globset",
- "lazy_static",
- "log",
- "memchr",
- "regex",
- "same-file",
- "thread_local",
- "walkdir",
- "winapi-util",
+ "base64 0.20.0",
+ "clap 3.2.23",
+ "merk",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1758,6 +1851,18 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
 ]
 
 [[package]]
@@ -1772,14 +1877,14 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "inventory"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84344c6e0b90a9e2b6f3f9abe5cc74402684e348df7b32adca28747e0cef091a"
+checksum = "16fe3b35d64bd1f72917f06425e7573a2f63f74f42c8f56e53ea6826dde3a2b5"
 dependencies = [
  "ctor",
  "ghost",
@@ -1807,6 +1912,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,12 +1930,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "kvstore"
+version = "0.1.0"
+dependencies = [
+ "clap 3.2.23",
+ "hex",
+ "indicatif",
+ "many-client",
+ "many-error",
+ "many-identity",
+ "many-identity-dsa",
+ "many-modules",
+ "many-protocol",
+ "many-types",
+ "minicbor",
+ "syslog-tracing",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1837,10 +1983,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "ledger"
+version = "0.1.0"
+dependencies = [
+ "clap 3.2.23",
+ "crc-any",
+ "hex",
+ "humantime",
+ "indicatif",
+ "lazy_static",
+ "many-client",
+ "many-error",
+ "many-identity",
+ "many-identity-dsa",
+ "many-identity-hsm",
+ "many-modules",
+ "many-protocol",
+ "many-types",
+ "minicbor",
+ "num-bigint",
+ "regex",
+ "ring",
+ "rpassword 6.0.1",
+ "syslog-tracing",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "ledger-db"
+version = "0.1.0"
+dependencies = [
+ "clap 3.2.23",
+ "hex",
+ "many-modules",
+ "many-types",
+ "merk",
+ "minicbor",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.13.4+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -1848,8 +2047,22 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.8.0+7.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+dependencies = [
+ "bindgen 0.60.1",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
 ]
 
 [[package]]
@@ -1873,10 +2086,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
+name = "libz-sys"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linkme"
@@ -1914,44 +2133,51 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
-name = "many"
+name = "many-abci"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "async-recursion",
- "atty",
- "base64 0.13.1",
- "cbor-diag",
+ "async-trait",
+ "ciborium",
  "clap 3.2.23",
  "coset",
  "hex",
+ "itertools",
+ "json5",
+ "lazy_static",
  "many-client",
  "many-error",
  "many-identity",
  "many-identity-dsa",
- "many-identity-hsm",
  "many-identity-webauthn",
- "many-mock",
  "many-modules",
  "many-protocol",
  "many-server",
  "many-types",
  "minicbor",
- "rand 0.8.5",
- "rpassword 6.0.1",
+ "num-integer",
+ "reqwest",
+ "sha2 0.10.6",
+ "signal-hook",
+ "smol",
+ "syslog-tracing",
+ "tendermint",
+ "tendermint-abci",
+ "tendermint-proto",
+ "tendermint-rpc",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "url",
+ "vergen",
 ]
 
 [[package]]
 name = "many-client"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1978,7 +2204,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "p256",
- "pem",
  "pkcs8 0.8.0",
  "rand 0.8.5",
  "regex",
@@ -1995,6 +2220,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2004,30 +2230,27 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
- "backtrace",
  "minicbor",
  "num-derive",
  "num-traits",
  "regex",
- "tracing",
 ]
 
 [[package]]
 name = "many-identity"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "base32",
  "coset",
  "crc-any",
  "hex",
  "many-error",
- "many-identity",
  "minicbor",
  "once_cell",
- "proptest",
  "serde",
- "serde_test",
  "sha2 0.10.6",
  "sha3 0.10.6",
  "signature",
@@ -2038,6 +2261,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "asn1 0.8.7",
  "base32",
@@ -2049,17 +2273,13 @@ dependencies = [
  "hex",
  "many-error",
  "many-identity",
- "many-identity-dsa",
- "many-protocol",
  "minicbor",
  "once_cell",
  "p256",
  "pkcs8 0.8.0",
- "proptest",
  "rand 0.7.3",
  "rand 0.8.5",
  "serde",
- "serde_test",
  "sha2 0.10.6",
  "sha3 0.10.6",
  "signature",
@@ -2069,6 +2289,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "asn1 0.10.0",
  "coset",
@@ -2088,12 +2309,12 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "authenticator-ctap2-2021",
  "base64 0.13.1",
  "base64urlsafedata",
  "coset",
- "hex",
  "many-error",
  "many-identity",
  "many-identity-dsa",
@@ -2115,8 +2336,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "many-kvstore"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "clap 3.2.23",
+ "coset",
+ "hex",
+ "itertools",
+ "json5",
+ "lazy_static",
+ "many-error",
+ "many-identity",
+ "many-identity-dsa",
+ "many-modules",
+ "many-protocol",
+ "many-server",
+ "many-types",
+ "merk",
+ "minicbor",
+ "num-bigint",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "sha3 0.10.6",
+ "signal-hook",
+ "simple_asn1",
+ "strum",
+ "syslog-tracing",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "vergen",
+]
+
+[[package]]
+name = "many-ledger"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "base64 0.20.0",
+ "bip39-dict",
+ "clap 3.2.23",
+ "coset",
+ "fixed",
+ "hex",
+ "itertools",
+ "json5",
+ "linkme",
+ "many-client",
+ "many-error",
+ "many-identity",
+ "many-identity-dsa",
+ "many-identity-webauthn",
+ "many-ledger",
+ "many-migration",
+ "many-modules",
+ "many-protocol",
+ "many-server",
+ "many-types",
+ "merk",
+ "minicbor",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "proptest",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha3 0.9.1",
+ "signal-hook",
+ "simple_asn1",
+ "strum",
+ "syslog-tracing",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "typenum",
+ "typetag",
+ "vergen",
+]
+
+[[package]]
 name = "many-macros"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2129,8 +2435,8 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
- "linkme",
  "many-error",
  "minicbor",
  "serde",
@@ -2140,51 +2446,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "many-mock"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "cbor-diag",
- "ciborium",
- "coset",
- "cucumber",
- "futures",
- "many-client",
- "many-error",
- "many-identity",
- "many-identity-dsa",
- "many-identity-webauthn",
- "many-modules",
- "many-protocol",
- "many-server",
- "regex",
- "serde",
- "serde_json",
- "tokio",
- "toml",
-]
-
-[[package]]
 name = "many-modules"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "async-trait",
- "cbor-diag",
  "coset",
  "derive_builder 0.11.2",
  "hex",
  "many-error",
  "many-identity",
- "many-identity-dsa",
  "many-macros",
  "many-protocol",
  "many-types",
  "minicbor",
- "mockall",
  "num-bigint",
- "once_cell",
- "proptest",
- "smol",
  "strum",
  "strum_macros",
 ]
@@ -2192,6 +2468,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2204,8 +2481,6 @@ dependencies = [
  "num-bigint",
  "num-derive",
  "num-traits",
- "once_cell",
- "proptest",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -2217,11 +2492,11 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "anyhow",
  "asn1 0.11.0",
  "async-trait",
- "backtrace",
  "base32",
  "base64 0.13.1",
  "coset",
@@ -2236,11 +2511,9 @@ dependencies = [
  "lazy_static",
  "many-error",
  "many-identity",
- "many-identity-dsa",
  "many-macros",
  "many-modules",
  "many-protocol",
- "many-server",
  "many-types",
  "minicbor",
  "num-bigint",
@@ -2248,19 +2521,15 @@ dependencies = [
  "num-traits",
  "once_cell",
  "p256",
- "pem",
  "pkcs8 0.8.0",
- "proptest",
  "rand 0.8.5",
  "regex",
  "reqwest",
- "semver",
  "serde",
  "serde_json",
  "sha2 0.10.6",
  "sha3 0.9.1",
  "signature",
- "smol",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -2272,22 +2541,19 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=dea01257edc567cf27d0194bb344f1822952cecf#dea01257edc567cf27d0194bb344f1822952cecf"
 dependencies = [
  "base64 0.20.0",
- "cbor-diag",
  "coset",
  "fixed",
  "hex",
  "many-error",
  "many-identity",
- "many-types",
  "minicbor",
  "num-bigint",
  "num-derive",
  "num-traits",
- "proptest",
  "serde",
- "serde_test",
 ]
 
 [[package]]
@@ -2303,6 +2569,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "merk"
+version = "1.0.0"
+source = "git+https://github.com/liftedinit/merk.git?rev=da0b660abbfd58abd4a942773f205d2c079f3b27#da0b660abbfd58abd4a942773f205d2c079f3b27"
+dependencies = [
+ "blake3",
+ "byteorder",
+ "colored",
+ "ed",
+ "hex",
+ "num_cpus",
+ "rand 0.8.5",
+ "rocksdb",
+ "thiserror",
 ]
 
 [[package]]
@@ -2339,15 +2621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,33 +2630,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "mockall"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2405,13 +2651,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "5.1.2"
+name = "new_mime_guess"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "c2d684d1b59e0dc07b37e2203ef576987473288f530082512aff850585c61b1f"
 dependencies = [
- "memchr",
- "version_check",
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -2425,21 +2671,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom_locate"
-version = "4.0.0"
+name = "ntapi"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37794436ca3029a3089e0b95d42da1f0b565ad271e4d3bb4bad0c7bb70b10605"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
 dependencies = [
- "bytecount",
- "memchr",
- "nom 7.1.1",
+ "winapi",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2484,18 +2722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,13 +2741,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.29.0"
+name = "number_prefix"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
-dependencies = [
- "memchr",
-]
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oid-registry"
@@ -2537,9 +2760,6 @@ name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
-dependencies = [
- "parking_lot_core",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -2554,7 +2774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2637,7 +2857,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -2645,12 +2865,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
 name = "pbkdf2"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.11.1",
 ]
 
 [[package]]
@@ -2670,9 +2896,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "peg"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+checksum = "07c0b841ea54f523f7aa556956fbd293bcbe06f2e67d2eb732b7278aaf1d166a"
 dependencies = [
  "peg-macros",
  "peg-runtime",
@@ -2680,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "peg-macros"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+checksum = "b5aa52829b8decbef693af90202711348ab001456803ba2a98eb4ec8fb70844c"
 dependencies = [
  "peg-runtime",
  "proc-macro2",
@@ -2691,18 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "peg-runtime"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
-
-[[package]]
-name = "pem"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
-dependencies = [
- "base64 0.13.1",
-]
+checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2727,6 +2944,70 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pest"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha1",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2794,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-ffi",
@@ -2806,36 +3087,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "predicates"
-version = "2.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -2888,6 +3139,39 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
+]
+
+[[package]]
+name = "prost"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -3064,6 +3348,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rpassword"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,16 +3401,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d79b4b604167921892e84afbbaad9d5ad74e091bf6c511d9dbfb0593f09fabd"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -3109,7 +3421,32 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom 7.1.1",
+ "nom",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.1",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3183,27 +3520,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sealed"
-version = "0.3.0"
+name = "sct"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636b9882a0f4cc2039488df89a10eb4b7976d4b6c1917fc0518f3f0f5e2c72ca"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sealed"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5e421024b5e5edfbaa8e60ecf90bda9dbffc602dbb230e6028763f85f0c68c"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3234,12 +3557,6 @@ name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
-
-[[package]]
-name = "separator"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
@@ -3302,12 +3619,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_test"
-version = "1.0.149"
+name = "serde_repr"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3434c4787dcd7c8c0837ffbb01e6e34091f8983b2df9655e66393a867f99f7aa"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
- "serde",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3334,13 +3653,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -3352,7 +3682,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -3424,6 +3754,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +3806,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -3517,7 +3865,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3529,6 +3877,21 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "subtle-encoding"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -3554,36 +3917,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "synthez"
-version = "0.2.0"
+name = "sysinfo"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033178d0acccffc5490021657006e6a8dd586ee9dc6f7c24e7608b125e568cb1"
+checksum = "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
 dependencies = [
- "syn",
- "synthez-codegen",
- "synthez-core",
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
-name = "synthez-codegen"
-version = "0.2.0"
+name = "syslog-tracing"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69263462a40e46960f070618e20094ce69e783a41f86e54bc75545136afd597a"
+checksum = "4cf9ff1f9f8e5ba220a58bbccb0375f4cabd785f96a8683b31389cefd91be747"
 dependencies = [
- "syn",
- "synthez-core",
-]
-
-[[package]]
-name = "synthez-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb8b5a4089fe1723279f06302afda64a5dacaa11a82bcbb4d08759590d4389d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "sealed 0.3.0",
- "syn",
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3598,12 +3953,120 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.24.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c321f411bdfb772bca0c5d9c94d8f45e3a992fae44baa60d17b99d8aaae58d04"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.9.9",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint-abci"
+version = "0.24.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f53ac0f0d3c1e479c35db7fe815257be95a1c9b37630b0a58292766ecf1a65e9"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "prost",
+ "tendermint-proto",
+ "tracing",
+]
+
+[[package]]
+name = "tendermint-config"
+version = "0.24.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3eac1b63f911a7524ab44a67dcf4370dd44a3ee8f9e6524bd7be426dcfdc55"
+dependencies = [
+ "flex-error",
+ "serde",
+ "serde_json",
+ "tendermint",
+ "toml",
+ "url",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.24.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5820a81dfb85011220d2b24323870ad30a56ae446f92b170911574c79d385bc5"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.24.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f2a9433b4385bf54dbda310fa6df993b6777123d77caa08119361ce6fb7d628"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "flex-error",
+ "futures",
+ "getrandom 0.2.8",
+ "http",
+ "hyper",
+ "hyper-proxy",
+ "hyper-rustls",
+ "peg",
+ "pin-project",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "subtle",
+ "subtle-encoding",
+ "tendermint",
+ "tendermint-config",
+ "tendermint-proto",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid 0.8.2",
+ "walkdir",
 ]
 
 [[package]]
@@ -3626,25 +4089,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]
@@ -3781,6 +4229,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,7 +4274,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3874,10 +4333,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "typed-builder"
-version = "0.7.1"
+name = "typenum"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85f4270f4f449a3f2c0cf2aecc8415e388a597aeacc7d55fc749c5c968c8533"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "typetag"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63205b6a08578f24e4288dd01692d5d215b0c2e90613089187d2e9879788ed94"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5fd220a6403b4959b40a7f276a8d8d52a987b010dd8efd5c923f8f2d8933132"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3885,10 +4363,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.16.0"
+name = "ucd-trie"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -3912,12 +4399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,6 +4411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3940,6 +4427,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
@@ -3968,6 +4461,24 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vergen"
+version = "7.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447f9238a4553957277b3ee09d80babeae0811f1b3baefb093de1c0448437a37"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustc_version",
+ "rustversion",
+ "sysinfo",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "version_check"
@@ -4029,7 +4540,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -4054,7 +4565,7 @@ version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4108,7 +4619,7 @@ dependencies = [
  "authenticator-ctap2-2021",
  "base64urlsafedata",
  "hidapi",
- "nom 7.1.1",
+ "nom",
  "openssl",
  "rpassword 5.0.1",
  "serde",
@@ -4116,7 +4627,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.2.2",
  "webauthn-rs-proto",
 ]
 
@@ -4130,7 +4641,7 @@ dependencies = [
  "serde",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.2.2",
  "webauthn-rs-core",
 ]
 
@@ -4144,7 +4655,7 @@ dependencies = [
  "base64urlsafedata",
  "compact_jwt",
  "der-parser",
- "nom 7.1.1",
+ "nom",
  "openssl",
  "rand 0.8.5",
  "serde",
@@ -4153,7 +4664,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.2.2",
  "webauthn-rs-proto",
  "x509-parser",
 ]
@@ -4168,6 +4679,25 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]
@@ -4341,7 +4871,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom 7.1.1",
+ "nom",
  "oid-registry",
  "rusticata-macros",
  "thiserror",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,20 +2,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "dd79bd4e2e2adabae738c5e93c36d351cf18071ff2acf6590190acf4138984f6",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.14.0/rules_rust-v0.14.0.tar.gz"],
+    sha256 = "5c2b6745236f8ce547f82eeacbbcc81d736734cc8bd92e60d3e3cdfa6e167bb5",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.15.0/rules_rust-v0.15.0.tar.gz"],
 )
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
 
 rules_rust_dependencies()
 
-RUST_VERSION = "nightly"
+RUST_VERSION = "nightly/2022-11-13"
 
 rust_register_toolchains(
     edition = "2021",
-    iso_date = "2022-11-13",
-    version = RUST_VERSION,
+    versions = [RUST_VERSION],
 )
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fa16b2ad984c9332776bc3ddb0ed43a6157e85c324494702525060647d330113",
+  "checksum": "9565ca907d5e092e9478b35d260991c8e529b4455c23b5aeaa7bd46a5bebedcd",
   "crates": {
     "aes 0.7.5": {
       "name": "aes",
@@ -210,6 +210,75 @@
         ]
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "arrayref 0.3.6": {
+      "name": "arrayref",
+      "version": "0.3.6",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/arrayref/0.3.6/download",
+          "sha256": "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "arrayref",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "arrayref",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.3.6"
+      },
+      "license": "BSD-2-Clause"
+    },
+    "arrayvec 0.5.2": {
+      "name": "arrayvec",
+      "version": "0.5.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/arrayvec/0.5.2/download",
+          "sha256": "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "arrayvec",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "arrayvec",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "array-sizes-33-128"
+        ],
+        "edition": "2018",
+        "version": "0.5.2"
+      },
+      "license": "MIT/Apache-2.0"
     },
     "ascii 1.1.0": {
       "name": "ascii",
@@ -1170,56 +1239,6 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-recursion 1.0.0": {
-      "name": "async-recursion",
-      "version": "1.0.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/async-recursion/1.0.0/download",
-          "sha256": "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "async_recursion",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "async_recursion",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.47",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.21",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.105",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.0.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "async-task 4.3.0": {
       "name": "async-task",
       "version": "4.3.0",
@@ -1996,6 +2015,170 @@
       },
       "license": "BSD-3-Clause"
     },
+    "bindgen 0.60.1": {
+      "name": "bindgen",
+      "version": "0.60.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/bindgen/0.60.1/download",
+          "sha256": "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bindgen",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "Binary": {
+            "crate_name": "bindgen",
+            "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "bindgen",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "runtime"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bindgen 0.60.1",
+              "target": "build_script_build"
+            },
+            {
+              "id": "bitflags 1.3.2",
+              "target": "bitflags"
+            },
+            {
+              "id": "cexpr 0.6.0",
+              "target": "cexpr"
+            },
+            {
+              "id": "clang-sys 1.4.0",
+              "target": "clang_sys"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            },
+            {
+              "id": "lazycell 1.3.0",
+              "target": "lazycell"
+            },
+            {
+              "id": "peeking_take_while 0.1.2",
+              "target": "peeking_take_while"
+            },
+            {
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "regex 1.7.0",
+              "target": "regex"
+            },
+            {
+              "id": "rustc-hash 1.1.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "shlex 1.1.0",
+              "target": "shlex"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.60.1"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "BSD-3-Clause"
+    },
+    "bip39-dict 0.1.1": {
+      "name": "bip39-dict",
+      "version": "0.1.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/bip39-dict/0.1.1/download",
+          "sha256": "33b74d395d6b577a1e3c1348545cef70a418281c83abbe50f5662ae4d4abf6d8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bip39_dict",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "bip39_dict",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "english"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cryptoxide 0.4.2",
+              "target": "cryptoxide"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.1"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "bit-set 0.5.3": {
       "name": "bit-set",
       "version": "0.5.3",
@@ -2113,6 +2296,102 @@
         "version": "1.3.2"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "blake3 0.3.8": {
+      "name": "blake3",
+      "version": "0.3.8",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/blake3/0.3.8/download",
+          "sha256": "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "blake3",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "blake3",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "arrayref 0.3.6",
+              "target": "arrayref"
+            },
+            {
+              "id": "arrayvec 0.5.2",
+              "target": "arrayvec"
+            },
+            {
+              "id": "blake3 0.3.8",
+              "target": "build_script_build"
+            },
+            {
+              "id": "cfg-if 0.1.10",
+              "target": "cfg_if"
+            },
+            {
+              "id": "constant_time_eq 0.1.5",
+              "target": "constant_time_eq"
+            },
+            {
+              "id": "crypto-mac 0.8.0",
+              "target": "crypto_mac"
+            },
+            {
+              "id": "digest 0.9.0",
+              "target": "digest"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.8"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.0.77",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "CC0-1.0 OR Apache-2.0"
     },
     "block-buffer 0.10.3": {
       "name": "block-buffer",
@@ -2346,87 +2625,6 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "bs58 0.4.0": {
-      "name": "bs58",
-      "version": "0.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/bs58/0.4.0/download",
-          "sha256": "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "bs58",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "bs58",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "alloc"
-        ],
-        "edition": "2018",
-        "version": "0.4.0"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "bstr 0.2.17": {
-      "name": "bstr",
-      "version": "0.2.17",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/bstr/0.2.17/download",
-          "sha256": "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "bstr",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "bstr",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "std"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "memchr 2.5.0",
-              "target": "memchr"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.2.17"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "bumpalo 3.11.1": {
       "name": "bumpalo",
       "version": "3.11.1",
@@ -2462,39 +2660,6 @@
         "version": "3.11.1"
       },
       "license": "MIT/Apache-2.0"
-    },
-    "bytecount 0.6.3": {
-      "name": "bytecount",
-      "version": "0.6.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/bytecount/0.6.3/download",
-          "sha256": "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "bytecount",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "bytecount",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.6.3"
-      },
-      "license": "Apache-2.0/MIT"
     },
     "bytemuck 1.12.3": {
       "name": "bytemuck",
@@ -2558,6 +2723,7 @@
           "**"
         ],
         "crate_features": [
+          "default",
           "i128",
           "std"
         ],
@@ -2596,27 +2762,49 @@
         ],
         "crate_features": [
           "default",
+          "serde",
           "std"
         ],
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
         "version": "1.3.0"
       },
       "license": "MIT"
     },
-    "cbor-diag 0.1.11": {
-      "name": "cbor-diag",
-      "version": "0.1.11",
+    "bzip2-sys 0.1.11+1.0.8": {
+      "name": "bzip2-sys",
+      "version": "0.1.11+1.0.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cbor-diag/0.1.11/download",
-          "sha256": "2644c5bb01d8328b218301180b84ccc6f7fce031d50e30917b07ae762a185b7b"
+          "url": "https://crates.io/api/v1/crates/bzip2-sys/0.1.11+1.0.8/download",
+          "sha256": "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "cbor_diag",
-            "crate_root": "src/lib.rs",
+            "crate_name": "bzip2_sys",
+            "crate_root": "lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -2626,64 +2814,50 @@
           }
         }
       ],
-      "library_target_name": "cbor_diag",
+      "library_target_name": "bzip2_sys",
       "common_attrs": {
         "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "static"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bzip2-sys 0.1.11+1.0.8",
+              "target": "build_script_build"
+            },
+            {
+              "id": "libc 0.2.138",
+              "target": "libc"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.1.11+1.0.8"
+      },
+      "build_script_attrs": {
+        "data_glob": [
           "**"
         ],
         "deps": {
           "common": [
             {
-              "id": "bs58 0.4.0",
-              "target": "bs58"
+              "id": "cc 1.0.77",
+              "target": "cc"
             },
             {
-              "id": "chrono 0.4.23",
-              "target": "chrono"
-            },
-            {
-              "id": "data-encoding 2.3.3",
-              "target": "data_encoding"
-            },
-            {
-              "id": "half 2.1.0",
-              "target": "half"
-            },
-            {
-              "id": "nom 5.1.2",
-              "target": "nom"
-            },
-            {
-              "id": "num-bigint 0.4.3",
-              "target": "num_bigint"
-            },
-            {
-              "id": "num-rational 0.4.1",
-              "target": "num_rational"
-            },
-            {
-              "id": "num-traits 0.2.15",
-              "target": "num_traits"
-            },
-            {
-              "id": "separator 0.4.1",
-              "target": "separator"
-            },
-            {
-              "id": "url 2.3.1",
-              "target": "url"
-            },
-            {
-              "id": "uuid 1.2.2",
-              "target": "uuid"
+              "id": "pkg-config 0.3.26",
+              "target": "pkg_config"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.1.11"
+        "links": "bzip2"
       },
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT/Apache-2.0"
     },
     "cc 1.0.77": {
       "name": "cc",
@@ -2725,6 +2899,19 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": [
+          "jobserver",
+          "parallel"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "jobserver 0.1.25",
+              "target": "jobserver"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
         "version": "1.0.77"
       },
@@ -2771,6 +2958,39 @@
         "version": "0.6.0"
       },
       "license": "Apache-2.0/MIT"
+    },
+    "cfg-if 0.1.10": {
+      "name": "cfg-if",
+      "version": "0.1.10",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/cfg-if/0.1.10/download",
+          "sha256": "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "cfg_if",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "cfg_if",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.1.10"
+      },
+      "license": "MIT/Apache-2.0"
     },
     "cfg-if 1.0.0": {
       "name": "cfg-if",
@@ -2891,9 +3111,12 @@
       "name": "ciborium",
       "version": "0.2.0",
       "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ciborium/0.2.0/download",
-          "sha256": "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+        "Git": {
+          "remote": "https://github.com/enarx/ciborium",
+          "commitish": {
+            "Rev": "2ca375e6b33d1ade5a5798792278b35a807b748e"
+          },
+          "strip_prefix": "ciborium"
         }
       },
       "targets": [
@@ -2945,9 +3168,12 @@
       "name": "ciborium-io",
       "version": "0.2.0",
       "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ciborium-io/0.2.0/download",
-          "sha256": "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+        "Git": {
+          "remote": "https://github.com/enarx/ciborium",
+          "commitish": {
+            "Rev": "2ca375e6b33d1ade5a5798792278b35a807b748e"
+          },
+          "strip_prefix": "ciborium-io"
         }
       },
       "targets": [
@@ -2982,9 +3208,12 @@
       "name": "ciborium-ll",
       "version": "0.2.0",
       "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ciborium-ll/0.2.0/download",
-          "sha256": "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+        "Git": {
+          "remote": "https://github.com/enarx/ciborium",
+          "commitish": {
+            "Rev": "2ca375e6b33d1ade5a5798792278b35a807b748e"
+          },
+          "strip_prefix": "ciborium-ll"
         }
       },
       "targets": [
@@ -3443,6 +3672,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "colored 1.9.3": {
+      "name": "colored",
+      "version": "1.9.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/colored/1.9.3/download",
+          "sha256": "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "colored",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "colored",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "atty 0.2.14",
+              "target": "atty"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            }
+          ],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2015",
+        "version": "1.9.3"
+      },
+      "license": "MPL-2.0"
+    },
     "compact_jwt 0.2.9": {
       "name": "compact_jwt",
       "version": "0.2.9",
@@ -3595,11 +3877,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": [
-          "ansi-parsing",
-          "default",
-          "unicode-width"
-        ],
         "deps": {
           "common": [
             {
@@ -3613,10 +3890,6 @@
             {
               "id": "terminal_size 0.1.17",
               "target": "terminal_size"
-            },
-            {
-              "id": "unicode-width 0.1.10",
-              "target": "unicode_width"
             }
           ],
           "selects": {
@@ -3702,6 +3975,39 @@
         "version": "0.7.1"
       },
       "license": "Apache-2.0 OR MIT"
+    },
+    "constant_time_eq 0.1.5": {
+      "name": "constant_time_eq",
+      "version": "0.1.5",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/constant_time_eq/0.1.5/download",
+          "sha256": "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "constant_time_eq",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "constant_time_eq",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.1.5"
+      },
+      "license": "CC0-1.0"
     },
     "core-foundation 0.9.3": {
       "name": "core-foundation",
@@ -3997,10 +4303,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": [
-          "default",
-          "std"
-        ],
         "deps": {
           "common": [
             {
@@ -4243,6 +4545,52 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "crypto-mac 0.8.0": {
+      "name": "crypto-mac",
+      "version": "0.8.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/crypto-mac/0.8.0/download",
+          "sha256": "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crypto_mac",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "crypto_mac",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "generic-array 0.14.6",
+              "target": "generic_array"
+            },
+            {
+              "id": "subtle 2.4.1",
+              "target": "subtle"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.8.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "cryptoki 0.3.0": {
       "name": "cryptoki",
       "version": "0.3.0",
@@ -4385,6 +4733,101 @@
       },
       "license": "Apache-2.0"
     },
+    "cryptoxide 0.4.2": {
+      "name": "cryptoxide",
+      "version": "0.4.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/cryptoxide/0.4.2/download",
+          "sha256": "129eabb7b0b78644a3a7e7cf220714aba47463bb281f69fa7a71ca5d12564cca"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "cryptoxide",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "cryptoxide",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "blake2",
+          "chacha",
+          "curve25519",
+          "default",
+          "digest",
+          "ed25519",
+          "hkdf",
+          "hmac",
+          "mac",
+          "pbkdf2",
+          "poly1305",
+          "ripemd160",
+          "salsa",
+          "scrypt",
+          "sha1",
+          "sha2",
+          "sha3",
+          "x25519"
+        ],
+        "edition": "2018",
+        "version": "0.4.2"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "ct-logs 0.8.0": {
+      "name": "ct-logs",
+      "version": "0.8.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ct-logs/0.8.0/download",
+          "sha256": "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ct_logs",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "ct_logs",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "sct 0.6.1",
+              "target": "sct"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.8.0"
+      },
+      "license": "Apache-2.0/ISC/MIT"
+    },
     "ctor 0.1.26": {
       "name": "ctor",
       "version": "0.1.26",
@@ -4430,267 +4873,6 @@
         "version": "0.1.26"
       },
       "license": "Apache-2.0 OR MIT"
-    },
-    "cucumber 0.13.0": {
-      "name": "cucumber",
-      "version": "0.13.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/cucumber/0.13.0/download",
-          "sha256": "399fa7fc41ab7163fc49d5c2613b582b04bbf2d5342fcb1946fc1efd5b71193c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "cucumber",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "cucumber",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "cucumber-codegen",
-          "cucumber-expressions",
-          "default",
-          "inventory",
-          "macros"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "atty 0.2.14",
-              "target": "atty"
-            },
-            {
-              "id": "clap 3.2.23",
-              "target": "clap"
-            },
-            {
-              "id": "console 0.15.2",
-              "target": "console"
-            },
-            {
-              "id": "cucumber-expressions 0.2.1",
-              "target": "cucumber_expressions"
-            },
-            {
-              "id": "either 1.8.0",
-              "target": "either"
-            },
-            {
-              "id": "futures 0.3.25",
-              "target": "futures"
-            },
-            {
-              "id": "gherkin 0.12.0",
-              "target": "gherkin"
-            },
-            {
-              "id": "globwalk 0.8.1",
-              "target": "globwalk"
-            },
-            {
-              "id": "inventory 0.2.3",
-              "target": "inventory"
-            },
-            {
-              "id": "itertools 0.10.5",
-              "target": "itertools"
-            },
-            {
-              "id": "linked-hash-map 0.5.6",
-              "target": "linked_hash_map"
-            },
-            {
-              "id": "once_cell 1.16.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "regex 1.7.0",
-              "target": "regex"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "async-trait 0.1.59",
-              "target": "async_trait"
-            },
-            {
-              "id": "cucumber-codegen 0.13.0",
-              "target": "cucumber_codegen"
-            },
-            {
-              "id": "derive_more 0.99.17",
-              "target": "derive_more"
-            },
-            {
-              "id": "sealed 0.4.0",
-              "target": "sealed"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.13.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "cucumber-codegen 0.13.0": {
-      "name": "cucumber-codegen",
-      "version": "0.13.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/cucumber-codegen/0.13.0/download",
-          "sha256": "6a6f939adacd640286fb794ec392c068367991795db4c2c9112b748fb4fbf04f"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "cucumber_codegen",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "cucumber_codegen",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cucumber-expressions 0.2.1",
-              "target": "cucumber_expressions"
-            },
-            {
-              "id": "inflections 1.1.1",
-              "target": "inflections"
-            },
-            {
-              "id": "itertools 0.10.5",
-              "target": "itertools"
-            },
-            {
-              "id": "proc-macro2 1.0.47",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.21",
-              "target": "quote"
-            },
-            {
-              "id": "regex 1.7.0",
-              "target": "regex"
-            },
-            {
-              "id": "syn 1.0.105",
-              "target": "syn"
-            },
-            {
-              "id": "synthez 0.2.0",
-              "target": "synthez"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "cucumber-expressions 0.2.1": {
-      "name": "cucumber-expressions",
-      "version": "0.2.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/cucumber-expressions/0.2.1/download",
-          "sha256": "d40d2fdf5e1bb4ae7e6b25c97bf9b9d249a02243fc0fbd91075592b5f00a3bc1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "cucumber_expressions",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "cucumber_expressions",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "either",
-          "into-regex",
-          "regex",
-          "regex-syntax"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "either 1.8.0",
-              "target": "either"
-            },
-            {
-              "id": "nom 7.1.1",
-              "target": "nom"
-            },
-            {
-              "id": "nom_locate 4.0.0",
-              "target": "nom_locate"
-            },
-            {
-              "id": "regex 1.7.0",
-              "target": "regex"
-            },
-            {
-              "id": "regex-syntax 0.6.28",
-              "target": "regex_syntax"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "derive_more 0.99.17",
-              "target": "derive_more"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.2.1"
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "curve25519-dalek 3.2.0": {
       "name": "curve25519-dalek",
@@ -4752,6 +4934,69 @@
         },
         "edition": "2015",
         "version": "3.2.0"
+      },
+      "license": "BSD-3-Clause"
+    },
+    "curve25519-dalek-ng 4.1.1": {
+      "name": "curve25519-dalek-ng",
+      "version": "4.1.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/curve25519-dalek-ng/4.1.1/download",
+          "sha256": "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "curve25519_dalek_ng",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "curve25519_dalek_ng",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "alloc",
+          "u64_backend"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "byteorder 1.4.3",
+              "target": "byteorder"
+            },
+            {
+              "id": "digest 0.9.0",
+              "target": "digest"
+            },
+            {
+              "id": "rand_core 0.6.4",
+              "target": "rand_core"
+            },
+            {
+              "id": "subtle-ng 2.5.0",
+              "target": "subtle_ng",
+              "alias": "subtle"
+            },
+            {
+              "id": "zeroize 1.4.3",
+              "target": "zeroize"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "4.1.1"
       },
       "license": "BSD-3-Clause"
     },
@@ -5684,65 +5929,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "derive_more 0.99.17": {
-      "name": "derive_more",
-      "version": "0.99.17",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/derive_more/0.99.17/download",
-          "sha256": "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "derive_more",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "derive_more",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "as_ref",
-          "deref",
-          "deref_mut",
-          "display",
-          "error",
-          "from",
-          "into"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.47",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.21",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.105",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.99.17"
-      },
-      "license": "MIT"
-    },
     "devd-rs 0.3.6": {
       "name": "devd-rs",
       "version": "0.3.6",
@@ -5788,39 +5974,6 @@
         "version": "0.3.6"
       },
       "license": "Unlicense/MIT"
-    },
-    "difflib 0.4.0": {
-      "name": "difflib",
-      "version": "0.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/difflib/0.4.0/download",
-          "sha256": "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "difflib",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "difflib",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.4.0"
-      },
-      "license": "MIT"
     },
     "digest 0.10.6": {
       "name": "digest",
@@ -5981,43 +6134,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "downcast 0.11.0": {
-      "name": "downcast",
-      "version": "0.11.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/downcast/0.11.0/download",
-          "sha256": "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "downcast",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "downcast",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "default",
-          "std"
-        ],
-        "edition": "2018",
-        "version": "0.11.0"
-      },
-      "license": "MIT"
-    },
     "ecdsa 0.12.4": {
       "name": "ecdsa",
       "version": "0.12.4",
@@ -6085,6 +6201,109 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
+    "ed 0.2.2-alpha.0": {
+      "name": "ed",
+      "version": "0.2.2-alpha.0",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/nomic-io/ed",
+          "commitish": {
+            "Rev": "dd28e9f9e7c97827dde943ee8decfcdf25b3cc83"
+          }
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ed",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "ed",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "thiserror 1.0.37",
+              "target": "thiserror"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "ed-derive 0.2.3",
+              "target": "ed_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.2.2-alpha.0"
+      },
+      "license": "MIT"
+    },
+    "ed-derive 0.2.3": {
+      "name": "ed-derive",
+      "version": "0.2.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ed-derive/0.2.3/download",
+          "sha256": "06a91d774f4b861acaa791bc6165e66d72d3a5d1aa85fc8c0956f5580f863161"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "ed_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "ed_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.105",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.2.3"
+      },
+      "license": "MIT"
+    },
     "ed25519 1.5.2": {
       "name": "ed25519",
       "version": "1.5.2",
@@ -6130,6 +6349,65 @@
         "version": "1.5.2"
       },
       "license": "Apache-2.0 OR MIT"
+    },
+    "ed25519-consensus 1.2.1": {
+      "name": "ed25519-consensus",
+      "version": "1.2.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ed25519-consensus/1.2.1/download",
+          "sha256": "758e2a0cd8a6cdf483e1d369e7d081647e00b88d8953e34d8f2cbba05ae28368"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ed25519_consensus",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "ed25519_consensus",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "curve25519-dalek-ng 4.1.1",
+              "target": "curve25519_dalek_ng",
+              "alias": "curve25519_dalek"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "rand_core 0.6.4",
+              "target": "rand_core"
+            },
+            {
+              "id": "sha2 0.9.9",
+              "target": "sha2"
+            },
+            {
+              "id": "zeroize 1.4.3",
+              "target": "zeroize"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.2.1"
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "ed25519-dalek 1.0.1": {
       "name": "ed25519-dalek",
@@ -6423,6 +6701,98 @@
       },
       "license": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
     },
+    "enum-iterator 1.1.3": {
+      "name": "enum-iterator",
+      "version": "1.1.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/enum-iterator/1.1.3/download",
+          "sha256": "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "enum_iterator",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "enum_iterator",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "enum-iterator-derive 1.1.0",
+              "target": "enum_iterator_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "1.1.3"
+      },
+      "license": "0BSD"
+    },
+    "enum-iterator-derive 1.1.0": {
+      "name": "enum-iterator-derive",
+      "version": "1.1.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/enum-iterator-derive/1.1.0/download",
+          "sha256": "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "enum_iterator_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "enum_iterator_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.105",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.1.0"
+      },
+      "license": "0BSD"
+    },
     "env_logger 0.9.3": {
       "name": "env_logger",
       "version": "0.9.3",
@@ -6488,6 +6858,72 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "erased-serde 0.3.24": {
+      "name": "erased-serde",
+      "version": "0.3.24",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/erased-serde/0.3.24/download",
+          "sha256": "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "erased_serde",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "erased_serde",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "alloc"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "erased-serde 0.3.24",
+              "target": "build_script_build"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.24"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "event-listener 2.5.3": {
       "name": "event-listener",
       "version": "2.5.3",
@@ -6520,6 +6956,78 @@
         "version": "2.5.3"
       },
       "license": "Apache-2.0 OR MIT"
+    },
+    "eyre 0.6.8": {
+      "name": "eyre",
+      "version": "0.6.8",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/eyre/0.6.8/download",
+          "sha256": "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "eyre",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "eyre",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "auto-install",
+          "default",
+          "track-caller"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "eyre 0.6.8",
+              "target": "build_script_build"
+            },
+            {
+              "id": "indenter 0.3.3",
+              "target": "indenter"
+            },
+            {
+              "id": "once_cell 1.16.0",
+              "target": "once_cell"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.6.8"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "fastrand 1.8.0": {
       "name": "fastrand",
@@ -6687,19 +7195,19 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "float-cmp 0.9.0": {
-      "name": "float-cmp",
-      "version": "0.9.0",
+    "flex-error 0.4.4": {
+      "name": "flex-error",
+      "version": "0.4.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/float-cmp/0.9.0/download",
-          "sha256": "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+          "url": "https://crates.io/api/v1/crates/flex-error/0.4.4/download",
+          "sha256": "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "float_cmp",
+            "crate_name": "flex_error",
             "crate_root": "src/lib.rs",
             "srcs": {
               "include": [
@@ -6710,29 +7218,38 @@
           }
         }
       ],
-      "library_target_name": "float_cmp",
+      "library_target_name": "flex_error",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
         "crate_features": [
-          "default",
-          "num-traits",
-          "ratio"
+          "eyre",
+          "eyre_tracer",
+          "std"
         ],
         "deps": {
           "common": [
             {
-              "id": "num-traits 0.2.15",
-              "target": "num_traits"
+              "id": "eyre 0.6.8",
+              "target": "eyre"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.9.0"
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "paste 1.0.11",
+              "target": "paste"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.4.4"
       },
-      "license": "MIT"
+      "license": "Apache-2.0"
     },
     "fnv 1.0.7": {
       "name": "fnv",
@@ -6887,39 +7404,6 @@
         "version": "1.1.0"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "fragile 2.0.0": {
-      "name": "fragile",
-      "version": "2.0.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/fragile/2.0.0/download",
-          "sha256": "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "fragile",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "fragile",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "2.0.0"
-      },
-      "license": "Apache-2.0"
     },
     "futures 0.3.25": {
       "name": "futures",
@@ -7495,6 +7979,7 @@
           "async-await",
           "async-await-macro",
           "channel",
+          "default",
           "futures-channel",
           "futures-io",
           "futures-macro",
@@ -7752,7 +8237,10 @@
           "**"
         ],
         "crate_features": [
-          "std"
+          "js",
+          "js-sys",
+          "std",
+          "wasm-bindgen"
         ],
         "deps": {
           "common": [
@@ -7762,6 +8250,16 @@
             }
           ],
           "selects": {
+            "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))": [
+              {
+                "id": "js-sys 0.3.60",
+                "target": "js_sys"
+              },
+              {
+                "id": "wasm-bindgen 0.2.83",
+                "target": "wasm_bindgen"
+              }
+            ],
             "cfg(target_os = \"wasi\")": [
               {
                 "id": "wasi 0.11.0+wasi-snapshot-preview1",
@@ -7781,32 +8279,20 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gherkin 0.12.0": {
-      "name": "gherkin",
-      "version": "0.12.0",
+    "getset 0.1.2": {
+      "name": "getset",
+      "version": "0.1.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gherkin/0.12.0/download",
-          "sha256": "98ab17bb865b7c4fbca5133801229aeb127e254a47c29fd26968195fce9458ab"
+          "url": "https://crates.io/api/v1/crates/getset/0.1.2/download",
+          "sha256": "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
         }
       },
       "targets": [
         {
-          "Library": {
-            "crate_name": "gherkin",
+          "ProcMacro": {
+            "crate_name": "getset",
             "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -7816,70 +8302,24 @@
           }
         }
       ],
-      "library_target_name": "gherkin",
+      "library_target_name": "getset",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": [
-          "default",
-          "parser",
-          "typed-builder"
-        ],
         "deps": {
           "common": [
             {
-              "id": "gherkin 0.12.0",
-              "target": "build_script_build"
+              "id": "proc-macro-error 1.0.4",
+              "target": "proc_macro_error"
             },
             {
-              "id": "peg 0.6.3",
-              "target": "peg"
-            },
-            {
-              "id": "textwrap 0.12.1",
-              "target": "textwrap"
-            },
-            {
-              "id": "thiserror 1.0.37",
-              "target": "thiserror"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "typed-builder 0.7.1",
-              "target": "typed_builder"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.12.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "heck 0.3.3",
-              "target": "heck"
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
             },
             {
               "id": "quote 1.0.21",
               "target": "quote"
-            },
-            {
-              "id": "serde 1.0.149",
-              "target": "serde"
-            },
-            {
-              "id": "serde_json 1.0.89",
-              "target": "serde_json"
             },
             {
               "id": "syn 1.0.105",
@@ -7887,9 +8327,11 @@
             }
           ],
           "selects": {}
-        }
+        },
+        "edition": "2018",
+        "version": "0.1.2"
       },
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT"
     },
     "ghost 0.1.6": {
       "name": "ghost",
@@ -7941,6 +8383,64 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "git2 0.14.4": {
+      "name": "git2",
+      "version": "0.14.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/git2/0.14.4/download",
+          "sha256": "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "git2",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "git2",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 1.3.2",
+              "target": "bitflags"
+            },
+            {
+              "id": "libc 0.2.138",
+              "target": "libc"
+            },
+            {
+              "id": "libgit2-sys 0.13.4+1.4.2",
+              "target": "libgit2_sys"
+            },
+            {
+              "id": "log 0.4.17",
+              "target": "log"
+            },
+            {
+              "id": "url 2.3.1",
+              "target": "url"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.14.4"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "glob 0.3.0": {
       "name": "glob",
       "version": "0.3.0",
@@ -7973,118 +8473,6 @@
         "version": "0.3.0"
       },
       "license": "MIT/Apache-2.0"
-    },
-    "globset 0.4.9": {
-      "name": "globset",
-      "version": "0.4.9",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/globset/0.4.9/download",
-          "sha256": "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "globset",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "globset",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "default",
-          "log"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "aho-corasick 0.7.20",
-              "target": "aho_corasick"
-            },
-            {
-              "id": "bstr 0.2.17",
-              "target": "bstr"
-            },
-            {
-              "id": "fnv 1.0.7",
-              "target": "fnv"
-            },
-            {
-              "id": "log 0.4.17",
-              "target": "log"
-            },
-            {
-              "id": "regex 1.7.0",
-              "target": "regex"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.4.9"
-      },
-      "license": "Unlicense OR MIT"
-    },
-    "globwalk 0.8.1": {
-      "name": "globwalk",
-      "version": "0.8.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/globwalk/0.8.1/download",
-          "sha256": "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "globwalk",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "globwalk",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 1.3.2",
-              "target": "bitflags"
-            },
-            {
-              "id": "ignore 0.4.18",
-              "target": "ignore"
-            },
-            {
-              "id": "walkdir 2.3.2",
-              "target": "walkdir"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.8.1"
-      },
-      "license": "MIT"
     },
     "group 0.10.0": {
       "name": "group",
@@ -8331,19 +8719,19 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "heck 0.3.3": {
-      "name": "heck",
-      "version": "0.3.3",
+    "headers 0.3.8": {
+      "name": "headers",
+      "version": "0.3.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/heck/0.3.3/download",
-          "sha256": "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+          "url": "https://crates.io/api/v1/crates/headers/0.3.8/download",
+          "sha256": "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "heck",
+            "crate_name": "headers",
             "crate_root": "src/lib.rs",
             "srcs": {
               "include": [
@@ -8354,7 +8742,7 @@
           }
         }
       ],
-      "library_target_name": "heck",
+      "library_target_name": "headers",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -8362,16 +8750,86 @@
         "deps": {
           "common": [
             {
-              "id": "unicode-segmentation 1.10.0",
-              "target": "unicode_segmentation"
+              "id": "base64 0.13.1",
+              "target": "base64"
+            },
+            {
+              "id": "bitflags 1.3.2",
+              "target": "bitflags"
+            },
+            {
+              "id": "bytes 1.3.0",
+              "target": "bytes"
+            },
+            {
+              "id": "headers-core 0.2.0",
+              "target": "headers_core"
+            },
+            {
+              "id": "http 0.2.8",
+              "target": "http"
+            },
+            {
+              "id": "httpdate 1.0.2",
+              "target": "httpdate"
+            },
+            {
+              "id": "mime 0.3.16",
+              "target": "mime"
+            },
+            {
+              "id": "sha1 0.10.5",
+              "target": "sha1"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.3.3"
+        "edition": "2015",
+        "version": "0.3.8"
       },
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT"
+    },
+    "headers-core 0.2.0": {
+      "name": "headers-core",
+      "version": "0.2.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/headers-core/0.2.0/download",
+          "sha256": "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "headers_core",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "headers_core",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "http 0.2.8",
+              "target": "http"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.2.0"
+      },
+      "license": "MIT"
     },
     "heck 0.4.0": {
       "name": "heck",
@@ -8485,8 +8943,18 @@
         "crate_features": [
           "alloc",
           "default",
+          "serde",
           "std"
         ],
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
         "version": "0.4.3"
       },
@@ -8769,6 +9237,91 @@
       },
       "license": "MIT"
     },
+    "http_proxy 0.1.0": {
+      "name": "http_proxy",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Binary": {
+            "crate_name": "http_proxy",
+            "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": null,
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "clap 3.2.23",
+              "target": "clap"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "many-client 0.1.0",
+              "target": "many_client"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-identity-dsa 0.1.0",
+              "target": "many_identity_dsa"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "minicbor 0.18.0",
+              "target": "minicbor"
+            },
+            {
+              "id": "new_mime_guess 4.0.1",
+              "target": "new_mime_guess"
+            },
+            {
+              "id": "syslog-tracing 0.1.0",
+              "target": "syslog_tracing"
+            },
+            {
+              "id": "tiny_http 0.11.0",
+              "target": "tiny_http"
+            },
+            {
+              "id": "tokio 1.23.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
+            },
+            {
+              "id": "tracing-subscriber 0.3.16",
+              "target": "tracing_subscriber"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "Apache-2.0"
+    },
     "httparse 1.8.0": {
       "name": "httparse",
       "version": "1.8.0",
@@ -8928,6 +9481,7 @@
         ],
         "crate_features": [
           "client",
+          "default",
           "h2",
           "http1",
           "http2",
@@ -9008,6 +9562,182 @@
         "version": "0.14.23"
       },
       "license": "MIT"
+    },
+    "hyper-proxy 0.9.1": {
+      "name": "hyper-proxy",
+      "version": "0.9.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/hyper-proxy/0.9.1/download",
+          "sha256": "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "hyper_proxy",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "hyper_proxy",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "hyper-rustls",
+          "rustls",
+          "rustls-base",
+          "rustls-native-certs",
+          "tokio-rustls",
+          "webpki"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.3.0",
+              "target": "bytes"
+            },
+            {
+              "id": "futures 0.3.25",
+              "target": "futures"
+            },
+            {
+              "id": "headers 0.3.8",
+              "target": "headers"
+            },
+            {
+              "id": "http 0.2.8",
+              "target": "http"
+            },
+            {
+              "id": "hyper 0.14.23",
+              "target": "hyper"
+            },
+            {
+              "id": "hyper-rustls 0.22.1",
+              "target": "hyper_rustls"
+            },
+            {
+              "id": "rustls-native-certs 0.5.0",
+              "target": "rustls_native_certs"
+            },
+            {
+              "id": "tokio 1.23.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-rustls 0.22.0",
+              "target": "tokio_rustls"
+            },
+            {
+              "id": "tower-service 0.3.2",
+              "target": "tower_service"
+            },
+            {
+              "id": "webpki 0.21.4",
+              "target": "webpki"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.9.1"
+      },
+      "license": "MIT"
+    },
+    "hyper-rustls 0.22.1": {
+      "name": "hyper-rustls",
+      "version": "0.22.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/hyper-rustls/0.22.1/download",
+          "sha256": "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "hyper_rustls",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "hyper_rustls",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "ct-logs",
+          "default",
+          "native-tokio",
+          "rustls-native-certs",
+          "tokio-runtime",
+          "webpki-roots"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "ct-logs 0.8.0",
+              "target": "ct_logs"
+            },
+            {
+              "id": "futures-util 0.3.25",
+              "target": "futures_util"
+            },
+            {
+              "id": "hyper 0.14.23",
+              "target": "hyper"
+            },
+            {
+              "id": "log 0.4.17",
+              "target": "log"
+            },
+            {
+              "id": "rustls 0.19.1",
+              "target": "rustls"
+            },
+            {
+              "id": "rustls-native-certs 0.5.0",
+              "target": "rustls_native_certs"
+            },
+            {
+              "id": "tokio 1.23.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-rustls 0.22.0",
+              "target": "tokio_rustls"
+            },
+            {
+              "id": "webpki 0.21.4",
+              "target": "webpki"
+            },
+            {
+              "id": "webpki-roots 0.21.1",
+              "target": "webpki_roots"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.22.1"
+      },
+      "license": "Apache-2.0/ISC/MIT"
     },
     "hyper-tls 0.5.0": {
       "name": "hyper-tls",
@@ -9146,19 +9876,81 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ignore 0.4.18": {
-      "name": "ignore",
-      "version": "0.4.18",
+    "idstore-export 0.1.0": {
+      "name": "idstore-export",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Binary": {
+            "crate_name": "idstore-export",
+            "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": null,
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "base64 0.20.0",
+              "target": "base64"
+            },
+            {
+              "id": "clap 3.2.23",
+              "target": "clap"
+            },
+            {
+              "id": "merk 1.0.0",
+              "target": "merk"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.89",
+              "target": "serde_json"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "serde_derive 1.0.149",
+              "target": "serde_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.1.0"
+      },
+      "license": "Apache-2.0"
+    },
+    "indenter 0.3.3": {
+      "name": "indenter",
+      "version": "0.3.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ignore/0.4.18/download",
-          "sha256": "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+          "url": "https://crates.io/api/v1/crates/indenter/0.3.3/download",
+          "sha256": "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "ignore",
+            "crate_name": "indenter",
             "crate_root": "src/lib.rs",
             "srcs": {
               "include": [
@@ -9169,63 +9961,18 @@
           }
         }
       ],
-      "library_target_name": "ignore",
+      "library_target_name": "indenter",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "deps": {
-          "common": [
-            {
-              "id": "crossbeam-utils 0.8.14",
-              "target": "crossbeam_utils"
-            },
-            {
-              "id": "globset 0.4.9",
-              "target": "globset"
-            },
-            {
-              "id": "lazy_static 1.4.0",
-              "target": "lazy_static"
-            },
-            {
-              "id": "log 0.4.17",
-              "target": "log"
-            },
-            {
-              "id": "memchr 2.5.0",
-              "target": "memchr"
-            },
-            {
-              "id": "regex 1.7.0",
-              "target": "regex"
-            },
-            {
-              "id": "same-file 1.0.6",
-              "target": "same_file"
-            },
-            {
-              "id": "thread_local 1.1.4",
-              "target": "thread_local"
-            },
-            {
-              "id": "walkdir 2.3.2",
-              "target": "walkdir"
-            }
-          ],
-          "selects": {
-            "cfg(windows)": [
-              {
-                "id": "winapi-util 0.1.5",
-                "target": "winapi_util"
-              }
-            ]
-          }
-        },
+        "crate_features": [
+          "default"
+        ],
         "edition": "2018",
-        "version": "0.4.18"
+        "version": "0.3.3"
       },
-      "license": "Unlicense/MIT"
+      "license": "MIT OR Apache-2.0"
     },
     "indexmap 1.9.2": {
       "name": "indexmap",
@@ -9302,6 +10049,63 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
+    "indicatif 0.16.2": {
+      "name": "indicatif",
+      "version": "0.16.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/indicatif/0.16.2/download",
+          "sha256": "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "indicatif",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "indicatif",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "console 0.15.2",
+              "target": "console"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            },
+            {
+              "id": "number_prefix 0.4.0",
+              "target": "number_prefix"
+            },
+            {
+              "id": "regex 1.7.0",
+              "target": "regex"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.16.2"
+      },
+      "license": "MIT"
+    },
     "inflections 1.1.1": {
       "name": "inflections",
       "version": "1.1.1",
@@ -9377,13 +10181,13 @@
       },
       "license": "BSD-3-Clause"
     },
-    "inventory 0.2.3": {
+    "inventory 0.3.3": {
       "name": "inventory",
-      "version": "0.2.3",
+      "version": "0.3.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/inventory/0.2.3/download",
-          "sha256": "84344c6e0b90a9e2b6f3f9abe5cc74402684e348df7b32adca28747e0cef091a"
+          "url": "https://crates.io/api/v1/crates/inventory/0.3.3/download",
+          "sha256": "16fe3b35d64bd1f72917f06425e7573a2f63f74f42c8f56e53ea6826dde3a2b5"
         }
       },
       "targets": [
@@ -9405,7 +10209,7 @@
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2018",
+        "edition": "2021",
         "proc_macro_deps": {
           "common": [
             {
@@ -9419,7 +10223,7 @@
           ],
           "selects": {}
         },
-        "version": "0.2.3"
+        "version": "0.3.3"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -9539,6 +10343,50 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "jobserver 0.1.25": {
+      "name": "jobserver",
+      "version": "0.1.25",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/jobserver/0.1.25/download",
+          "sha256": "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "jobserver",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "jobserver",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.138",
+                "target": "libc"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.1.25"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "js-sys 0.3.60": {
       "name": "js-sys",
       "version": "0.3.60",
@@ -9580,6 +10428,61 @@
         "version": "0.3.60"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "json5 0.4.1": {
+      "name": "json5",
+      "version": "0.4.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/json5/0.4.1/download",
+          "sha256": "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "json5",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "json5",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "pest 2.5.1",
+              "target": "pest"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "pest_derive 2.5.1",
+              "target": "pest_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.4.1"
+      },
+      "license": "ISC"
     },
     "keccak 0.1.3": {
       "name": "keccak",
@@ -9624,6 +10527,99 @@
         "version": "0.1.3"
       },
       "license": "Apache-2.0 OR MIT"
+    },
+    "kvstore 0.1.0": {
+      "name": "kvstore",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Binary": {
+            "crate_name": "kvstore",
+            "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": null,
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "clap 3.2.23",
+              "target": "clap"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "indicatif 0.16.2",
+              "target": "indicatif"
+            },
+            {
+              "id": "many-client 0.1.0",
+              "target": "many_client"
+            },
+            {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-identity-dsa 0.1.0",
+              "target": "many_identity_dsa"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
+              "id": "minicbor 0.18.0",
+              "target": "minicbor"
+            },
+            {
+              "id": "syslog-tracing 0.1.0",
+              "target": "syslog_tracing"
+            },
+            {
+              "id": "tokio 1.23.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
+            },
+            {
+              "id": "tracing-subscriber 0.3.16",
+              "target": "tracing_subscriber"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "Apache-2.0"
     },
     "lazy_static 1.4.0": {
       "name": "lazy_static",
@@ -9691,6 +10687,188 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "ledger 0.1.0": {
+      "name": "ledger",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Binary": {
+            "crate_name": "ledger",
+            "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": null,
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "clap 3.2.23",
+              "target": "clap"
+            },
+            {
+              "id": "crc-any 2.4.3",
+              "target": "crc_any"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "humantime 2.1.0",
+              "target": "humantime"
+            },
+            {
+              "id": "indicatif 0.16.2",
+              "target": "indicatif"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            },
+            {
+              "id": "many-client 0.1.0",
+              "target": "many_client"
+            },
+            {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-identity-dsa 0.1.0",
+              "target": "many_identity_dsa"
+            },
+            {
+              "id": "many-identity-hsm 0.1.0",
+              "target": "many_identity_hsm"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
+              "id": "minicbor 0.18.0",
+              "target": "minicbor"
+            },
+            {
+              "id": "num-bigint 0.4.3",
+              "target": "num_bigint"
+            },
+            {
+              "id": "regex 1.7.0",
+              "target": "regex"
+            },
+            {
+              "id": "ring 0.16.20",
+              "target": "ring"
+            },
+            {
+              "id": "rpassword 6.0.1",
+              "target": "rpassword"
+            },
+            {
+              "id": "syslog-tracing 0.1.0",
+              "target": "syslog_tracing"
+            },
+            {
+              "id": "tokio 1.23.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
+            },
+            {
+              "id": "tracing-subscriber 0.3.16",
+              "target": "tracing_subscriber"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "Apache-2.0"
+    },
+    "ledger-db 0.1.0": {
+      "name": "ledger-db",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Binary": {
+            "crate_name": "ledger-db",
+            "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": null,
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "clap 3.2.23",
+              "target": "clap"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
+              "id": "merk 1.0.0",
+              "target": "merk"
+            },
+            {
+              "id": "minicbor 0.18.0",
+              "target": "minicbor"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "Apache-2.0"
+    },
     "libc 0.2.138": {
       "name": "libc",
       "version": "0.2.138",
@@ -9754,6 +10932,87 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "libgit2-sys 0.13.4+1.4.2": {
+      "name": "libgit2-sys",
+      "version": "0.13.4+1.4.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/libgit2-sys/0.13.4+1.4.2/download",
+          "sha256": "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "libgit2_sys",
+            "crate_root": "lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "libgit2_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "libc 0.2.138",
+              "target": "libc"
+            },
+            {
+              "id": "libgit2-sys 0.13.4+1.4.2",
+              "target": "build_script_build"
+            },
+            {
+              "id": "libz-sys 1.1.8",
+              "target": "libz_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.13.4+1.4.2"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.0.77",
+              "target": "cc"
+            },
+            {
+              "id": "pkg-config 0.3.26",
+              "target": "pkg_config"
+            }
+          ],
+          "selects": {}
+        },
+        "links": "git2"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "libloading 0.7.4": {
       "name": "libloading",
       "version": "0.7.4",
@@ -9803,6 +11062,105 @@
         "version": "0.7.4"
       },
       "license": "ISC"
+    },
+    "librocksdb-sys 0.8.0+7.4.4": {
+      "name": "librocksdb-sys",
+      "version": "0.8.0+7.4.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/librocksdb-sys/0.8.0+7.4.4/download",
+          "sha256": "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "librocksdb_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "librocksdb_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "static"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bzip2-sys 0.1.11+1.0.8",
+              "target": "bzip2_sys"
+            },
+            {
+              "id": "libc 0.2.138",
+              "target": "libc"
+            },
+            {
+              "id": "librocksdb-sys 0.8.0+7.4.4",
+              "target": "build_script_build"
+            },
+            {
+              "id": "libz-sys 1.1.8",
+              "target": "libz_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.8.0+7.4.4"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bindgen 0.60.1",
+              "target": "bindgen"
+            },
+            {
+              "id": "cc 1.0.77",
+              "target": "cc"
+            },
+            {
+              "id": "glob 0.3.0",
+              "target": "glob"
+            }
+          ],
+          "selects": {}
+        },
+        "build_script_env": {
+          "common": {
+            "CXXFLAGS": "-Wno-error=coverage-invalid-line-number"
+          },
+          "selects": {}
+        },
+        "links": "rocksdb"
+      },
+      "license": "MIT/Apache-2.0/BSD-3-Clause"
     },
     "libudev 0.2.0": {
       "name": "libudev",
@@ -9923,20 +11281,32 @@
       },
       "license": "MIT"
     },
-    "linked-hash-map 0.5.6": {
-      "name": "linked-hash-map",
-      "version": "0.5.6",
+    "libz-sys 1.1.8": {
+      "name": "libz-sys",
+      "version": "1.1.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/linked-hash-map/0.5.6/download",
-          "sha256": "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+          "url": "https://crates.io/api/v1/crates/libz-sys/1.1.8/download",
+          "sha256": "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "linked_hash_map",
+            "crate_name": "libz_sys",
             "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -9946,15 +11316,58 @@
           }
         }
       ],
-      "library_target_name": "linked_hash_map",
+      "library_target_name": "libz_sys",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2015",
-        "version": "0.5.6"
+        "crate_features": [
+          "libc",
+          "static"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "libc 0.2.138",
+              "target": "libc"
+            },
+            {
+              "id": "libz-sys 1.1.8",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.1.8"
       },
-      "license": "MIT/Apache-2.0"
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.0.77",
+              "target": "cc"
+            },
+            {
+              "id": "pkg-config 0.3.26",
+              "target": "pkg_config"
+            }
+          ],
+          "selects": {
+            "cfg(target_env = \"msvc\")": [
+              {
+                "id": "vcpkg 0.2.15",
+                "target": "vcpkg"
+              }
+            ]
+          }
+        },
+        "links": "z"
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "linkme 0.3.6": {
       "name": "linkme",
@@ -10192,15 +11605,39 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "many 0.1.0": {
-      "name": "many",
+    "many-abci 0.1.0": {
+      "name": "many-abci",
       "version": "0.1.0",
       "repository": null,
       "targets": [
         {
+          "Library": {
+            "crate_name": "many_abci",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
           "Binary": {
-            "crate_name": "many",
+            "crate_name": "many-abci",
             "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -10210,7 +11647,7 @@
           }
         }
       ],
-      "library_target_name": null,
+      "library_target_name": "many_abci",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -10218,20 +11655,8 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.66",
-              "target": "anyhow"
-            },
-            {
-              "id": "atty 0.2.14",
-              "target": "atty"
-            },
-            {
-              "id": "base64 0.13.1",
-              "target": "base64"
-            },
-            {
-              "id": "cbor-diag 0.1.11",
-              "target": "cbor_diag"
+              "id": "ciborium 0.2.0",
+              "target": "ciborium"
             },
             {
               "id": "clap 3.2.23",
@@ -10246,16 +11671,100 @@
               "target": "hex"
             },
             {
+              "id": "itertools 0.10.5",
+              "target": "itertools"
+            },
+            {
+              "id": "json5 0.4.1",
+              "target": "json5"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            },
+            {
+              "id": "many-abci 0.1.0",
+              "target": "build_script_build"
+            },
+            {
+              "id": "many-client 0.1.0",
+              "target": "many_client"
+            },
+            {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-identity-dsa 0.1.0",
+              "target": "many_identity_dsa"
+            },
+            {
+              "id": "many-identity-webauthn 0.1.0",
+              "target": "many_identity_webauthn"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
+              "id": "many-server 0.1.0",
+              "target": "many_server"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
               "id": "minicbor 0.18.0",
               "target": "minicbor"
             },
             {
-              "id": "rand 0.8.5",
-              "target": "rand"
+              "id": "num-integer 0.1.45",
+              "target": "num_integer"
             },
             {
-              "id": "rpassword 6.0.1",
-              "target": "rpassword"
+              "id": "reqwest 0.11.13",
+              "target": "reqwest"
+            },
+            {
+              "id": "sha2 0.10.6",
+              "target": "sha2"
+            },
+            {
+              "id": "signal-hook 0.3.14",
+              "target": "signal_hook"
+            },
+            {
+              "id": "smol 1.3.0",
+              "target": "smol"
+            },
+            {
+              "id": "syslog-tracing 0.1.0",
+              "target": "syslog_tracing"
+            },
+            {
+              "id": "tendermint 0.24.0-pre.2",
+              "target": "tendermint"
+            },
+            {
+              "id": "tendermint-abci 0.24.0-pre.2",
+              "target": "tendermint_abci"
+            },
+            {
+              "id": "tendermint-proto 0.24.0-pre.2",
+              "target": "tendermint_proto"
+            },
+            {
+              "id": "tendermint-rpc 0.24.0-pre.2",
+              "target": "tendermint_rpc"
             },
             {
               "id": "tokio 1.23.0",
@@ -10268,10 +11777,6 @@
             {
               "id": "tracing-subscriber 0.3.16",
               "target": "tracing_subscriber"
-            },
-            {
-              "id": "url 2.3.1",
-              "target": "url"
             }
           ],
           "selects": {}
@@ -10280,20 +11785,42 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-recursion 1.0.0",
-              "target": "async_recursion"
+              "id": "async-trait 0.1.59",
+              "target": "async_trait"
             }
           ],
           "selects": {}
         },
         "version": "0.1.0"
       },
-      "license": null
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "vergen 7.4.3",
+              "target": "vergen"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "Apache-2.0"
     },
     "many-client 0.1.0": {
       "name": "many-client",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-client"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -10367,6 +11894,30 @@
               "target": "lazy_static"
             },
             {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-identity-dsa 0.1.0",
+              "target": "many_identity_dsa"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
+              "id": "many-server 0.1.0",
+              "target": "many_server"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
               "id": "minicbor 0.18.0",
               "target": "minicbor"
             },
@@ -10437,6 +11988,10 @@
               "target": "async_trait"
             },
             {
+              "id": "many-client-macros 0.1.0",
+              "target": "many_client_macros"
+            },
+            {
               "id": "num-derive 0.3.3",
               "target": "num_derive"
             }
@@ -10450,7 +12005,15 @@
     "many-client-macros 0.1.0": {
       "name": "many-client-macros",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-client-macros"
+        }
+      },
       "targets": [
         {
           "ProcMacro": {
@@ -10495,7 +12058,15 @@
     "many-error 0.1.0": {
       "name": "many-error",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-error"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -10553,7 +12124,15 @@
     "many-identity 0.1.0": {
       "name": "many-identity",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-identity"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -10600,6 +12179,10 @@
               "target": "hex"
             },
             {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
               "id": "minicbor 0.18.0",
               "target": "minicbor"
             },
@@ -10634,19 +12217,6 @@
           ],
           "selects": {}
         },
-        "deps_dev": {
-          "common": [
-            {
-              "id": "proptest 1.0.0",
-              "target": "proptest"
-            },
-            {
-              "id": "serde_test 1.0.149",
-              "target": "serde_test"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "version": "0.1.0"
       },
@@ -10655,7 +12225,15 @@
     "many-identity-dsa 0.1.0": {
       "name": "many-identity-dsa",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-identity-dsa"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -10681,7 +12259,6 @@
           "ecdsa",
           "ed25519",
           "minicbor",
-          "serde",
           "testing"
         ],
         "deps": {
@@ -10717,6 +12294,14 @@
             {
               "id": "hex 0.4.3",
               "target": "hex"
+            },
+            {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
             },
             {
               "id": "minicbor 0.18.0",
@@ -10766,19 +12351,6 @@
           ],
           "selects": {}
         },
-        "deps_dev": {
-          "common": [
-            {
-              "id": "proptest 1.0.0",
-              "target": "proptest"
-            },
-            {
-              "id": "serde_test 1.0.149",
-              "target": "serde_test"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "version": "0.1.0"
       },
@@ -10787,7 +12359,15 @@
     "many-identity-hsm 0.1.0": {
       "name": "many-identity-hsm",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-identity-hsm"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -10826,6 +12406,22 @@
               "target": "hex"
             },
             {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-identity-dsa 0.1.0",
+              "target": "many_identity_dsa"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
               "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
@@ -10856,7 +12452,15 @@
     "many-identity-webauthn 0.1.0": {
       "name": "many-identity-webauthn",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-identity-webauthn"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -10897,6 +12501,30 @@
             {
               "id": "coset 0.3.3",
               "target": "coset"
+            },
+            {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-identity-dsa 0.1.0",
+              "target": "many_identity_dsa"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
             },
             {
               "id": "minicbor 0.18.0",
@@ -10949,24 +12577,473 @@
           ],
           "selects": {}
         },
-        "deps_dev": {
-          "common": [
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "version": "0.1.0"
       },
       "license": null
     },
+    "many-kvstore 0.1.0": {
+      "name": "many-kvstore",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "many_kvstore",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "Binary": {
+            "crate_name": "many-kvstore",
+            "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "many_kvstore",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "clap 3.2.23",
+              "target": "clap"
+            },
+            {
+              "id": "coset 0.3.3",
+              "target": "coset"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "itertools 0.10.5",
+              "target": "itertools"
+            },
+            {
+              "id": "json5 0.4.1",
+              "target": "json5"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            },
+            {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-identity-dsa 0.1.0",
+              "target": "many_identity_dsa"
+            },
+            {
+              "id": "many-kvstore 0.1.0",
+              "target": "build_script_build"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
+              "id": "many-server 0.1.0",
+              "target": "many_server"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
+              "id": "merk 1.0.0",
+              "target": "merk"
+            },
+            {
+              "id": "minicbor 0.18.0",
+              "target": "minicbor"
+            },
+            {
+              "id": "num-bigint 0.4.3",
+              "target": "num_bigint"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.89",
+              "target": "serde_json"
+            },
+            {
+              "id": "sha3 0.10.6",
+              "target": "sha3"
+            },
+            {
+              "id": "signal-hook 0.3.14",
+              "target": "signal_hook"
+            },
+            {
+              "id": "simple_asn1 0.6.2",
+              "target": "simple_asn1"
+            },
+            {
+              "id": "strum 0.24.1",
+              "target": "strum"
+            },
+            {
+              "id": "syslog-tracing 0.1.0",
+              "target": "syslog_tracing"
+            },
+            {
+              "id": "tokio 1.23.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
+            },
+            {
+              "id": "tracing-subscriber 0.3.16",
+              "target": "tracing_subscriber"
+            }
+          ],
+          "selects": {}
+        },
+        "deps_dev": {
+          "common": [
+            {
+              "id": "once_cell 1.16.0",
+              "target": "once_cell"
+            },
+            {
+              "id": "tempfile 3.3.0",
+              "target": "tempfile"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "async-trait 0.1.59",
+              "target": "async_trait"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.1.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "vergen 7.4.3",
+              "target": "vergen"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "Apache-2.0"
+    },
+    "many-ledger 0.1.0": {
+      "name": "many-ledger",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "many_ledger",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "Binary": {
+            "crate_name": "many-ledger",
+            "crate_root": "src/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "many_ledger",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "balance_testing",
+          "migration_testing"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "base64 0.20.0",
+              "target": "base64"
+            },
+            {
+              "id": "bip39-dict 0.1.1",
+              "target": "bip39_dict"
+            },
+            {
+              "id": "clap 3.2.23",
+              "target": "clap"
+            },
+            {
+              "id": "coset 0.3.3",
+              "target": "coset"
+            },
+            {
+              "id": "fixed 1.20.0",
+              "target": "fixed"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "itertools 0.10.5",
+              "target": "itertools"
+            },
+            {
+              "id": "json5 0.4.1",
+              "target": "json5"
+            },
+            {
+              "id": "linkme 0.3.6",
+              "target": "linkme"
+            },
+            {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-identity-dsa 0.1.0",
+              "target": "many_identity_dsa"
+            },
+            {
+              "id": "many-identity-webauthn 0.1.0",
+              "target": "many_identity_webauthn"
+            },
+            {
+              "id": "many-ledger 0.1.0",
+              "target": "build_script_build"
+            },
+            {
+              "id": "many-migration 0.1.0",
+              "target": "many_migration"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
+              "id": "many-server 0.1.0",
+              "target": "many_server"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
+              "id": "merk 1.0.0",
+              "target": "merk"
+            },
+            {
+              "id": "minicbor 0.18.0",
+              "target": "minicbor"
+            },
+            {
+              "id": "num-bigint 0.4.3",
+              "target": "num_bigint"
+            },
+            {
+              "id": "num-traits 0.2.15",
+              "target": "num_traits"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.89",
+              "target": "serde_json"
+            },
+            {
+              "id": "sha3 0.9.1",
+              "target": "sha3"
+            },
+            {
+              "id": "signal-hook 0.3.14",
+              "target": "signal_hook"
+            },
+            {
+              "id": "simple_asn1 0.6.2",
+              "target": "simple_asn1"
+            },
+            {
+              "id": "strum 0.24.1",
+              "target": "strum"
+            },
+            {
+              "id": "syslog-tracing 0.1.0",
+              "target": "syslog_tracing"
+            },
+            {
+              "id": "tokio 1.23.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
+            },
+            {
+              "id": "tracing-subscriber 0.3.16",
+              "target": "tracing_subscriber"
+            },
+            {
+              "id": "typenum 1.16.0",
+              "target": "typenum"
+            },
+            {
+              "id": "typetag 0.2.4",
+              "target": "typetag"
+            }
+          ],
+          "selects": {}
+        },
+        "deps_dev": {
+          "common": [
+            {
+              "id": "many-client 0.1.0",
+              "target": "many_client"
+            },
+            {
+              "id": "once_cell 1.16.0",
+              "target": "once_cell"
+            },
+            {
+              "id": "proptest 1.0.0",
+              "target": "proptest"
+            },
+            {
+              "id": "tempfile 3.3.0",
+              "target": "tempfile"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "async-trait 0.1.59",
+              "target": "async_trait"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.1.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "vergen 7.4.3",
+              "target": "vergen"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "Apache-2.0"
+    },
     "many-macros 0.1.0": {
       "name": "many-macros",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-macros"
+        }
+      },
       "targets": [
         {
           "ProcMacro": {
@@ -11023,7 +13100,15 @@
     "many-migration 0.1.0": {
       "name": "many-migration",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-migration"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -11045,6 +13130,10 @@
         ],
         "deps": {
           "common": [
+            {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
             {
               "id": "minicbor 0.18.0",
               "target": "minicbor"
@@ -11068,103 +13157,7 @@
           ],
           "selects": {}
         },
-        "deps_dev": {
-          "common": [
-            {
-              "id": "linkme 0.3.6",
-              "target": "linkme"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
-        "version": "0.1.0"
-      },
-      "license": null
-    },
-    "many-mock 0.1.0": {
-      "name": "many-mock",
-      "version": "0.1.0",
-      "repository": null,
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "many_mock",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "many_mock",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cbor-diag 0.1.11",
-              "target": "cbor_diag"
-            },
-            {
-              "id": "coset 0.3.3",
-              "target": "coset"
-            },
-            {
-              "id": "regex 1.7.0",
-              "target": "regex"
-            },
-            {
-              "id": "serde 1.0.149",
-              "target": "serde"
-            },
-            {
-              "id": "toml 0.5.9",
-              "target": "toml"
-            }
-          ],
-          "selects": {}
-        },
-        "deps_dev": {
-          "common": [
-            {
-              "id": "ciborium 0.2.0",
-              "target": "ciborium"
-            },
-            {
-              "id": "cucumber 0.13.0",
-              "target": "cucumber"
-            },
-            {
-              "id": "futures 0.3.25",
-              "target": "futures"
-            },
-            {
-              "id": "serde_json 1.0.89",
-              "target": "serde_json"
-            },
-            {
-              "id": "tokio 1.23.0",
-              "target": "tokio"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "async-trait 0.1.59",
-              "target": "async_trait"
-            }
-          ],
-          "selects": {}
-        },
         "version": "0.1.0"
       },
       "license": null
@@ -11172,7 +13165,15 @@
     "many-modules 0.1.0": {
       "name": "many-modules",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-modules"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -11207,6 +13208,22 @@
               "target": "hex"
             },
             {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
               "id": "minicbor 0.18.0",
               "target": "minicbor"
             },
@@ -11221,37 +13238,16 @@
           ],
           "selects": {}
         },
-        "deps_dev": {
-          "common": [
-            {
-              "id": "cbor-diag 0.1.11",
-              "target": "cbor_diag"
-            },
-            {
-              "id": "mockall 0.11.3",
-              "target": "mockall"
-            },
-            {
-              "id": "once_cell 1.16.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "proptest 1.0.0",
-              "target": "proptest"
-            },
-            {
-              "id": "smol 1.3.0",
-              "target": "smol"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "proc_macro_deps": {
           "common": [
             {
               "id": "async-trait 0.1.59",
               "target": "async_trait"
+            },
+            {
+              "id": "many-macros 0.1.0",
+              "target": "many_macros"
             },
             {
               "id": "strum_macros 0.24.3",
@@ -11267,7 +13263,15 @@
     "many-protocol 0.1.0": {
       "name": "many-protocol",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-protocol"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -11304,6 +13308,18 @@
             {
               "id": "hex 0.4.3",
               "target": "hex"
+            },
+            {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
             },
             {
               "id": "minicbor 0.18.0",
@@ -11344,19 +13360,6 @@
           ],
           "selects": {}
         },
-        "deps_dev": {
-          "common": [
-            {
-              "id": "once_cell 1.16.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "proptest 1.0.0",
-              "target": "proptest"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "proc_macro_deps": {
           "common": [
@@ -11374,7 +13377,15 @@
     "many-server 0.1.0": {
       "name": "many-server",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-server"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -11395,8 +13406,7 @@
           "**"
         ],
         "crate_features": [
-          "default",
-          "testing"
+          "default"
         ],
         "deps": {
           "common": [
@@ -11457,6 +13467,26 @@
               "target": "lazy_static"
             },
             {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
+              "id": "many-modules 0.1.0",
+              "target": "many_modules"
+            },
+            {
+              "id": "many-protocol 0.1.0",
+              "target": "many_protocol"
+            },
+            {
+              "id": "many-types 0.1.0",
+              "target": "many_types"
+            },
+            {
               "id": "minicbor 0.18.0",
               "target": "minicbor"
             },
@@ -11535,29 +13565,16 @@
           ],
           "selects": {}
         },
-        "deps_dev": {
-          "common": [
-            {
-              "id": "proptest 1.0.0",
-              "target": "proptest"
-            },
-            {
-              "id": "semver 1.0.14",
-              "target": "semver"
-            },
-            {
-              "id": "smol 1.3.0",
-              "target": "smol"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "proc_macro_deps": {
           "common": [
             {
               "id": "async-trait 0.1.59",
               "target": "async_trait"
+            },
+            {
+              "id": "many-macros 0.1.0",
+              "target": "many_macros"
             },
             {
               "id": "num-derive 0.3.3",
@@ -11577,7 +13594,15 @@
     "many-types 0.1.0": {
       "name": "many-types",
       "version": "0.1.0",
-      "repository": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/many-rs.git",
+          "commitish": {
+            "Rev": "dea01257edc567cf27d0194bb344f1822952cecf"
+          },
+          "strip_prefix": "src/many-types"
+        }
+      },
       "targets": [
         {
           "Library": {
@@ -11596,9 +13621,6 @@
       "common_attrs": {
         "compile_data_glob": [
           "**"
-        ],
-        "crate_features": [
-          "proptest"
         ],
         "deps": {
           "common": [
@@ -11619,6 +13641,14 @@
               "target": "hex"
             },
             {
+              "id": "many-error 0.1.0",
+              "target": "many_error"
+            },
+            {
+              "id": "many-identity 0.1.0",
+              "target": "many_identity"
+            },
+            {
               "id": "minicbor 0.18.0",
               "target": "minicbor"
             },
@@ -11631,25 +13661,8 @@
               "target": "num_traits"
             },
             {
-              "id": "proptest 1.0.0",
-              "target": "proptest"
-            },
-            {
               "id": "serde 1.0.149",
               "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "deps_dev": {
-          "common": [
-            {
-              "id": "cbor-diag 0.1.11",
-              "target": "cbor_diag"
-            },
-            {
-              "id": "serde_test 1.0.149",
-              "target": "serde_test"
             }
           ],
           "selects": {}
@@ -11710,8 +13723,7 @@
         ],
         "crate_features": [
           "default",
-          "std",
-          "use_std"
+          "std"
         ],
         "deps": {
           "common": [
@@ -11800,6 +13812,95 @@
           ],
           "selects": {}
         }
+      },
+      "license": "MIT"
+    },
+    "merk 1.0.0": {
+      "name": "merk",
+      "version": "1.0.0",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/merk.git",
+          "commitish": {
+            "Rev": "da0b660abbfd58abd4a942773f205d2c079f3b27"
+          }
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "merk",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "merk",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "blake3",
+          "byteorder",
+          "colored",
+          "default",
+          "ed",
+          "full",
+          "hex",
+          "num_cpus",
+          "rand",
+          "rocksdb",
+          "verify"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "blake3 0.3.8",
+              "target": "blake3"
+            },
+            {
+              "id": "byteorder 1.4.3",
+              "target": "byteorder"
+            },
+            {
+              "id": "colored 1.9.3",
+              "target": "colored"
+            },
+            {
+              "id": "ed 0.2.2-alpha.0",
+              "target": "ed"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "num_cpus 1.14.0",
+              "target": "num_cpus"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            },
+            {
+              "id": "rocksdb 0.19.0",
+              "target": "rocksdb"
+            },
+            {
+              "id": "thiserror 1.0.37",
+              "target": "thiserror"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.0.0"
       },
       "license": "MIT"
     },
@@ -12088,131 +14189,6 @@
       },
       "license": "MIT"
     },
-    "mockall 0.11.3": {
-      "name": "mockall",
-      "version": "0.11.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/mockall/0.11.3/download",
-          "sha256": "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "mockall",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "mockall",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "downcast 0.11.0",
-              "target": "downcast"
-            },
-            {
-              "id": "fragile 2.0.0",
-              "target": "fragile"
-            },
-            {
-              "id": "lazy_static 1.4.0",
-              "target": "lazy_static"
-            },
-            {
-              "id": "predicates 2.1.4",
-              "target": "predicates"
-            },
-            {
-              "id": "predicates-tree 1.0.7",
-              "target": "predicates_tree"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "mockall_derive 0.11.3",
-              "target": "mockall_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.11.3"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "mockall_derive 0.11.3": {
-      "name": "mockall_derive",
-      "version": "0.11.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/mockall_derive/0.11.3/download",
-          "sha256": "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "mockall_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "mockall_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "proc-macro2 1.0.47",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.21",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.105",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.11.3"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "native-tls 0.2.11": {
       "name": "native-tls",
       "version": "0.2.11",
@@ -12319,19 +14295,19 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "nom 5.1.2": {
-      "name": "nom",
-      "version": "5.1.2",
+    "new_mime_guess 4.0.1": {
+      "name": "new_mime_guess",
+      "version": "4.0.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/nom/5.1.2/download",
-          "sha256": "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+          "url": "https://crates.io/api/v1/crates/new_mime_guess/4.0.1/download",
+          "sha256": "c2d684d1b59e0dc07b37e2203ef576987473288f530082512aff850585c61b1f"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "nom",
+            "crate_name": "new_mime_guess",
             "crate_root": "src/lib.rs",
             "srcs": {
               "include": [
@@ -12354,30 +14330,34 @@
           }
         }
       ],
-      "library_target_name": "nom",
+      "library_target_name": "new_mime_guess",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
         "crate_features": [
-          "alloc",
-          "std"
+          "default",
+          "rev-mappings"
         ],
         "deps": {
           "common": [
             {
-              "id": "memchr 2.5.0",
-              "target": "memchr"
+              "id": "mime 0.3.16",
+              "target": "mime"
             },
             {
-              "id": "nom 5.1.2",
+              "id": "new_mime_guess 4.0.1",
               "target": "build_script_build"
+            },
+            {
+              "id": "unicase 2.6.0",
+              "target": "unicase"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "5.1.2"
+        "version": "4.0.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12386,8 +14366,8 @@
         "deps": {
           "common": [
             {
-              "id": "version_check 0.9.4",
-              "target": "version_check"
+              "id": "unicase 2.6.0",
+              "target": "unicase"
             }
           ],
           "selects": {}
@@ -12446,20 +14426,32 @@
       },
       "license": "MIT"
     },
-    "nom_locate 4.0.0": {
-      "name": "nom_locate",
-      "version": "4.0.0",
+    "ntapi 0.4.0": {
+      "name": "ntapi",
+      "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/nom_locate/4.0.0/download",
-          "sha256": "37794436ca3029a3089e0b95d42da1f0b565ad271e4d3bb4bad0c7bb70b10605"
+          "url": "https://crates.io/api/v1/crates/ntapi/0.4.0/download",
+          "sha256": "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "nom_locate",
+            "crate_name": "ntapi",
             "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -12469,70 +14461,37 @@
           }
         }
       ],
-      "library_target_name": "nom_locate",
+      "library_target_name": "ntapi",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
         "crate_features": [
-          "alloc",
           "default",
-          "std"
+          "user"
         ],
         "deps": {
           "common": [
             {
-              "id": "bytecount 0.6.3",
-              "target": "bytecount"
+              "id": "ntapi 0.4.0",
+              "target": "build_script_build"
             },
             {
-              "id": "memchr 2.5.0",
-              "target": "memchr"
-            },
-            {
-              "id": "nom 7.1.1",
-              "target": "nom"
+              "id": "winapi 0.3.9",
+              "target": "winapi"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "4.0.0"
+        "version": "0.4.0"
       },
-      "license": "MIT"
-    },
-    "normalize-line-endings 0.3.0": {
-      "name": "normalize-line-endings",
-      "version": "0.3.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/normalize-line-endings/0.3.0/download",
-          "sha256": "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "normalize_line_endings",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "normalize_line_endings",
-      "common_attrs": {
-        "compile_data_glob": [
+      "build_script_attrs": {
+        "data_glob": [
           "**"
-        ],
-        "edition": "2015",
-        "version": "0.3.0"
+        ]
       },
-      "license": "Apache-2.0"
+      "license": "Apache-2.0 OR MIT"
     },
     "nu-ansi-term 0.46.0": {
       "name": "nu-ansi-term",
@@ -12754,6 +14713,7 @@
           "**"
         ],
         "crate_features": [
+          "default",
           "i128",
           "std"
         ],
@@ -12772,89 +14732,6 @@
         },
         "edition": "2015",
         "version": "0.1.45"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "autocfg 1.1.0",
-              "target": "autocfg"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "num-rational 0.4.1": {
-      "name": "num-rational",
-      "version": "0.4.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/num-rational/0.4.1/download",
-          "sha256": "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "num_rational",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "num_rational",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "num-bigint"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "num-bigint 0.4.3",
-              "target": "num_bigint"
-            },
-            {
-              "id": "num-integer 0.1.45",
-              "target": "num_integer"
-            },
-            {
-              "id": "num-rational 0.4.1",
-              "target": "build_script_build"
-            },
-            {
-              "id": "num-traits 0.2.15",
-              "target": "num_traits"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.4.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12995,6 +14872,43 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "number_prefix 0.4.0": {
+      "name": "number_prefix",
+      "version": "0.4.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/number_prefix/0.4.0/download",
+          "sha256": "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "number_prefix",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "number_prefix",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std"
+        ],
+        "edition": "2015",
+        "version": "0.4.0"
+      },
+      "license": "MIT"
+    },
     "oid-registry 0.4.0": {
       "name": "oid-registry",
       "version": "0.4.0",
@@ -13102,20 +15016,9 @@
         "crate_features": [
           "alloc",
           "default",
-          "parking_lot",
-          "parking_lot_core",
           "race",
           "std"
         ],
-        "deps": {
-          "common": [
-            {
-              "id": "parking_lot_core 0.9.5",
-              "target": "parking_lot_core"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "version": "1.16.0"
       },
@@ -13732,6 +15635,65 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "paste 1.0.11": {
+      "name": "paste",
+      "version": "1.0.11",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/paste/1.0.11/download",
+          "sha256": "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "paste",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "paste",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "paste 1.0.11",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.0.11"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "pbkdf2 0.10.1": {
       "name": "pbkdf2",
       "version": "0.10.1",
@@ -13849,13 +15811,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "peg 0.6.3": {
+    "peg 0.7.0": {
       "name": "peg",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/peg/0.6.3/download",
-          "sha256": "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+          "url": "https://crates.io/api/v1/crates/peg/0.7.0/download",
+          "sha256": "07c0b841ea54f523f7aa556956fbd293bcbe06f2e67d2eb732b7278aaf1d166a"
         }
       },
       "targets": [
@@ -13880,7 +15842,7 @@
         "deps": {
           "common": [
             {
-              "id": "peg-runtime 0.6.3",
+              "id": "peg-runtime 0.7.0",
               "target": "peg_runtime"
             }
           ],
@@ -13890,23 +15852,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "peg-macros 0.6.3",
+              "id": "peg-macros 0.7.0",
               "target": "peg_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.6.3"
+        "version": "0.7.0"
       },
       "license": "MIT"
     },
-    "peg-macros 0.6.3": {
+    "peg-macros 0.7.0": {
       "name": "peg-macros",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/peg-macros/0.6.3/download",
-          "sha256": "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+          "url": "https://crates.io/api/v1/crates/peg-macros/0.7.0/download",
+          "sha256": "b5aa52829b8decbef693af90202711348ab001456803ba2a98eb4ec8fb70844c"
         }
       },
       "targets": [
@@ -13943,7 +15905,7 @@
         "deps": {
           "common": [
             {
-              "id": "peg-runtime 0.6.3",
+              "id": "peg-runtime 0.7.0",
               "target": "peg_runtime"
             },
             {
@@ -13958,17 +15920,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.6.3"
+        "version": "0.7.0"
       },
       "license": "MIT"
     },
-    "peg-runtime 0.6.3": {
+    "peg-runtime 0.7.0": {
       "name": "peg-runtime",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/peg-runtime/0.6.3/download",
-          "sha256": "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+          "url": "https://crates.io/api/v1/crates/peg-runtime/0.7.0/download",
+          "sha256": "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
         }
       },
       "targets": [
@@ -13991,7 +15953,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.6.3"
+        "version": "0.7.0"
       },
       "license": "MIT"
     },
@@ -14121,6 +16083,306 @@
         "version": "2.2.0"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "pest 2.5.1": {
+      "name": "pest",
+      "version": "2.5.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/pest/2.5.1/download",
+          "sha256": "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "pest",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "pest",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std",
+          "thiserror"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "thiserror 1.0.37",
+              "target": "thiserror"
+            },
+            {
+              "id": "ucd-trie 0.1.5",
+              "target": "ucd_trie"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.5.1"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "pest_derive 2.5.1": {
+      "name": "pest_derive",
+      "version": "2.5.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/pest_derive/2.5.1/download",
+          "sha256": "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "pest_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "pest_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "pest 2.5.1",
+              "target": "pest"
+            },
+            {
+              "id": "pest_generator 2.5.1",
+              "target": "pest_generator"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.5.1"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "pest_generator 2.5.1": {
+      "name": "pest_generator",
+      "version": "2.5.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/pest_generator/2.5.1/download",
+          "sha256": "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "pest_generator",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "pest_generator",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "pest 2.5.1",
+              "target": "pest"
+            },
+            {
+              "id": "pest_meta 2.5.1",
+              "target": "pest_meta"
+            },
+            {
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.105",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.5.1"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "pest_meta 2.5.1": {
+      "name": "pest_meta",
+      "version": "2.5.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/pest_meta/2.5.1/download",
+          "sha256": "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "pest_meta",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "pest_meta",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "once_cell 1.16.0",
+              "target": "once_cell"
+            },
+            {
+              "id": "pest 2.5.1",
+              "target": "pest"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.5.1"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "pin-project 1.0.12": {
+      "name": "pin-project",
+      "version": "1.0.12",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/pin-project/1.0.12/download",
+          "sha256": "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "pin_project",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "pin_project",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "pin-project-internal 1.0.12",
+              "target": "pin_project_internal"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "1.0.12"
+      },
+      "license": "Apache-2.0 OR MIT"
+    },
+    "pin-project-internal 1.0.12": {
+      "name": "pin-project-internal",
+      "version": "1.0.12",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/pin-project-internal/1.0.12/download",
+          "sha256": "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "pin_project_internal",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "pin_project_internal",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.105",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.0.12"
+      },
+      "license": "Apache-2.0 OR MIT"
     },
     "pin-project-lite 0.2.9": {
       "name": "pin-project-lite",
@@ -14562,154 +16824,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "predicates 2.1.4": {
-      "name": "predicates",
-      "version": "2.1.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/predicates/2.1.4/download",
-          "sha256": "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "predicates",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "predicates",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "default",
-          "diff",
-          "float-cmp",
-          "normalize-line-endings",
-          "regex"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "difflib 0.4.0",
-              "target": "difflib"
-            },
-            {
-              "id": "float-cmp 0.9.0",
-              "target": "float_cmp"
-            },
-            {
-              "id": "itertools 0.10.5",
-              "target": "itertools"
-            },
-            {
-              "id": "normalize-line-endings 0.3.0",
-              "target": "normalize_line_endings"
-            },
-            {
-              "id": "predicates-core 1.0.5",
-              "target": "predicates_core"
-            },
-            {
-              "id": "regex 1.7.0",
-              "target": "regex"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.1.4"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "predicates-core 1.0.5": {
-      "name": "predicates-core",
-      "version": "1.0.5",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/predicates-core/1.0.5/download",
-          "sha256": "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "predicates_core",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "predicates_core",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "1.0.5"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "predicates-tree 1.0.7": {
-      "name": "predicates-tree",
-      "version": "1.0.7",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/predicates-tree/1.0.7/download",
-          "sha256": "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "predicates_tree",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "predicates_tree",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "predicates-core 1.0.5",
-              "target": "predicates_core"
-            },
-            {
-              "id": "termtree 0.4.0",
-              "target": "termtree"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.0.7"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "proc-macro-error 1.0.4": {
       "name": "proc-macro-error",
       "version": "1.0.4",
@@ -15046,6 +17160,164 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "prost 0.10.4": {
+      "name": "prost",
+      "version": "0.10.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/prost/0.10.4/download",
+          "sha256": "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "prost",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "prost",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "prost-derive"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.3.0",
+              "target": "bytes"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "prost-derive 0.10.1",
+              "target": "prost_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.10.4"
+      },
+      "license": "Apache-2.0"
+    },
+    "prost-derive 0.10.1": {
+      "name": "prost-derive",
+      "version": "0.10.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/prost-derive/0.10.1/download",
+          "sha256": "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "prost_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "prost_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.66",
+              "target": "anyhow"
+            },
+            {
+              "id": "itertools 0.10.5",
+              "target": "itertools"
+            },
+            {
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.105",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.10.1"
+      },
+      "license": "Apache-2.0"
+    },
+    "prost-types 0.10.1": {
+      "name": "prost-types",
+      "version": "0.10.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/prost-types/0.10.1/download",
+          "sha256": "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "prost_types",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "prost_types",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.3.0",
+              "target": "bytes"
+            },
+            {
+              "id": "prost 0.10.4",
+              "target": "prost"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.10.1"
+      },
+      "license": "Apache-2.0"
+    },
     "quick-error 1.2.3": {
       "name": "quick-error",
       "version": "1.2.3",
@@ -15287,6 +17559,7 @@
           "getrandom",
           "libc",
           "rand_chacha",
+          "small_rng",
           "std",
           "std_rng"
         ],
@@ -15961,6 +18234,166 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "ring 0.16.20": {
+      "name": "ring",
+      "version": "0.16.20",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ring/0.16.20/download",
+          "sha256": "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ring",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "ring",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "alloc",
+          "default",
+          "dev_urandom_fallback",
+          "once_cell"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "ring 0.16.20",
+              "target": "build_script_build"
+            },
+            {
+              "id": "untrusted 0.7.1",
+              "target": "untrusted"
+            }
+          ],
+          "selects": {
+            "cfg(all(target_arch = \"wasm32\", target_vendor = \"unknown\", target_os = \"unknown\", target_env = \"\"))": [
+              {
+                "id": "web-sys 0.3.60",
+                "target": "web_sys"
+              }
+            ],
+            "cfg(any(target_arch = \"x86\", target_arch = \"x86_64\", all(any(target_arch = \"aarch64\", target_arch = \"arm\"), any(target_os = \"android\", target_os = \"fuchsia\", target_os = \"linux\"))))": [
+              {
+                "id": "spin 0.5.2",
+                "target": "spin"
+              }
+            ],
+            "cfg(any(target_os = \"android\", target_os = \"linux\"))": [
+              {
+                "id": "libc 0.2.138",
+                "target": "libc"
+              },
+              {
+                "id": "once_cell 1.16.0",
+                "target": "once_cell"
+              }
+            ],
+            "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"illumos\", target_os = \"netbsd\", target_os = \"openbsd\", target_os = \"solaris\"))": [
+              {
+                "id": "once_cell 1.16.0",
+                "target": "once_cell"
+              }
+            ],
+            "cfg(target_os = \"windows\")": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.16.20"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.0.77",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        },
+        "links": "ring-asm"
+      },
+      "license": null
+    },
+    "rocksdb 0.19.0": {
+      "name": "rocksdb",
+      "version": "0.19.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/rocksdb/0.19.0/download",
+          "sha256": "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rocksdb",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "rocksdb",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "libc 0.2.138",
+              "target": "libc"
+            },
+            {
+              "id": "librocksdb-sys 0.8.0+7.4.4",
+              "target": "librocksdb_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.19.0"
+      },
+      "license": "Apache-2.0"
+    },
     "rpassword 5.0.1": {
       "name": "rpassword",
       "version": "5.0.1",
@@ -16140,6 +18573,48 @@
       },
       "license": "Apache-2.0/MIT"
     },
+    "rustc_version 0.4.0": {
+      "name": "rustc_version",
+      "version": "0.4.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/rustc_version/0.4.0/download",
+          "sha256": "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rustc_version",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustc_version",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "semver 1.0.14",
+              "target": "semver"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.4.0"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "rusticata-macros 4.1.0": {
       "name": "rusticata-macros",
       "version": "4.1.0",
@@ -16181,6 +18656,134 @@
         "version": "4.1.0"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "rustls 0.19.1": {
+      "name": "rustls",
+      "version": "0.19.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/rustls/0.19.1/download",
+          "sha256": "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rustls",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustls",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "log",
+          "logging"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "base64 0.13.1",
+              "target": "base64"
+            },
+            {
+              "id": "log 0.4.17",
+              "target": "log"
+            },
+            {
+              "id": "ring 0.16.20",
+              "target": "ring"
+            },
+            {
+              "id": "sct 0.6.1",
+              "target": "sct"
+            },
+            {
+              "id": "webpki 0.21.4",
+              "target": "webpki"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.19.1"
+      },
+      "license": "Apache-2.0/ISC/MIT"
+    },
+    "rustls-native-certs 0.5.0": {
+      "name": "rustls-native-certs",
+      "version": "0.5.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/rustls-native-certs/0.5.0/download",
+          "sha256": "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rustls_native_certs",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustls_native_certs",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "rustls"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rustls 0.19.1",
+              "target": "rustls"
+            }
+          ],
+          "selects": {
+            "cfg(all(unix, not(target_os = \"macos\")))": [
+              {
+                "id": "openssl-probe 0.1.5",
+                "target": "openssl_probe"
+              }
+            ],
+            "cfg(target_os = \"macos\")": [
+              {
+                "id": "security-framework 2.7.0",
+                "target": "security_framework"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "schannel 0.1.20",
+                "target": "schannel"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.5.0"
+      },
+      "license": "Apache-2.0/ISC/MIT"
     },
     "rustversion 1.0.9": {
       "name": "rustversion",
@@ -16554,19 +19157,19 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "sealed 0.3.0": {
-      "name": "sealed",
-      "version": "0.3.0",
+    "sct 0.6.1": {
+      "name": "sct",
+      "version": "0.6.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sealed/0.3.0/download",
-          "sha256": "636b9882a0f4cc2039488df89a10eb4b7976d4b6c1917fc0518f3f0f5e2c72ca"
+          "url": "https://crates.io/api/v1/crates/sct/0.6.1/download",
+          "sha256": "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
         }
       },
       "targets": [
         {
-          "ProcMacro": {
-            "crate_name": "sealed",
+          "Library": {
+            "crate_name": "sct",
             "crate_root": "src/lib.rs",
             "srcs": {
               "include": [
@@ -16577,7 +19180,7 @@
           }
         }
       ],
-      "library_target_name": "sealed",
+      "library_target_name": "sct",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -16585,82 +19188,20 @@
         "deps": {
           "common": [
             {
-              "id": "heck 0.3.3",
-              "target": "heck"
+              "id": "ring 0.16.20",
+              "target": "ring"
             },
             {
-              "id": "proc-macro2 1.0.47",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.21",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.105",
-              "target": "syn"
+              "id": "untrusted 0.7.1",
+              "target": "untrusted"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.0"
+        "version": "0.6.1"
       },
-      "license": "MIT OR Apache-2.0"
-    },
-    "sealed 0.4.0": {
-      "name": "sealed",
-      "version": "0.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/sealed/0.4.0/download",
-          "sha256": "6b5e421024b5e5edfbaa8e60ecf90bda9dbffc602dbb230e6028763f85f0c68c"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "sealed",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "sealed",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "heck 0.3.3",
-              "target": "heck"
-            },
-            {
-              "id": "proc-macro2 1.0.47",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.21",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.105",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.4.0"
-      },
-      "license": "MIT OR Apache-2.0"
+      "license": "Apache-2.0/ISC/MIT"
     },
     "security-framework 2.7.0": {
       "name": "security-framework",
@@ -16837,39 +19378,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "separator 0.4.1": {
-      "name": "separator",
-      "version": "0.4.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/separator/0.4.1/download",
-          "sha256": "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "separator",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "separator",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.4.1"
-      },
-      "license": "MIT"
-    },
     "serde 1.0.149": {
       "name": "serde",
       "version": "1.0.149",
@@ -16974,6 +19482,7 @@
           "**"
         ],
         "crate_features": [
+          "alloc",
           "default",
           "std"
         ],
@@ -17206,6 +19715,7 @@
           "**"
         ],
         "crate_features": [
+          "alloc",
           "default",
           "std"
         ],
@@ -17240,32 +19750,20 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_test 1.0.149": {
-      "name": "serde_test",
-      "version": "1.0.149",
+    "serde_repr 0.1.10": {
+      "name": "serde_repr",
+      "version": "0.1.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_test/1.0.149/download",
-          "sha256": "3434c4787dcd7c8c0837ffbb01e6e34091f8983b2df9655e66393a867f99f7aa"
+          "url": "https://crates.io/api/v1/crates/serde_repr/0.1.10/download",
+          "sha256": "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
         }
       },
       "targets": [
         {
-          "Library": {
-            "crate_name": "serde_test",
+          "ProcMacro": {
+            "crate_name": "serde_repr",
             "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -17275,7 +19773,7 @@
           }
         }
       ],
-      "library_target_name": "serde_test",
+      "library_target_name": "serde_repr",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -17283,23 +19781,22 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.149",
-              "target": "serde"
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
             },
             {
-              "id": "serde_test 1.0.149",
-              "target": "build_script_build"
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.105",
+              "target": "syn"
             }
           ],
           "selects": {}
         },
-        "edition": "2015",
-        "version": "1.0.149"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
+        "edition": "2018",
+        "version": "0.1.10"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -17406,6 +19903,63 @@
         "version": "0.7.1"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "sha1 0.10.5": {
+      "name": "sha1",
+      "version": "0.10.5",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/sha1/0.10.5/download",
+          "sha256": "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "sha1",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "sha1",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "digest 0.10.6",
+              "target": "digest"
+            }
+          ],
+          "selects": {
+            "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
+              {
+                "id": "cpufeatures 0.2.5",
+                "target": "cpufeatures"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.10.5"
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "sha2 0.10.6": {
       "name": "sha2",
@@ -17757,6 +20311,7 @@
         ],
         "crate_features": [
           "channel",
+          "default",
           "iterator"
         ],
         "deps": {
@@ -17881,6 +20436,60 @@
         "version": "1.3.2"
       },
       "license": "Apache-2.0 OR MIT"
+    },
+    "simple_asn1 0.6.2": {
+      "name": "simple_asn1",
+      "version": "0.6.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/simple_asn1/0.6.2/download",
+          "sha256": "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "simple_asn1",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "simple_asn1",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "num-bigint 0.4.3",
+              "target": "num_bigint"
+            },
+            {
+              "id": "num-traits 0.2.15",
+              "target": "num_traits"
+            },
+            {
+              "id": "thiserror 1.0.37",
+              "target": "thiserror"
+            },
+            {
+              "id": "time 0.3.17",
+              "target": "time"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.6.2"
+      },
+      "license": "ISC"
     },
     "slab 0.4.7": {
       "name": "slab",
@@ -18113,6 +20722,39 @@
         "version": "0.4.7"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "spin 0.5.2": {
+      "name": "spin",
+      "version": "0.5.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/spin/0.5.2/download",
+          "sha256": "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "spin",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "spin",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.5.2"
+      },
+      "license": "MIT"
     },
     "spki 0.4.1": {
       "name": "spki",
@@ -18455,6 +21097,88 @@
       },
       "license": "BSD-3-Clause"
     },
+    "subtle-encoding 0.5.1": {
+      "name": "subtle-encoding",
+      "version": "0.5.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/subtle-encoding/0.5.1/download",
+          "sha256": "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "subtle_encoding",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "subtle_encoding",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "alloc",
+          "base64",
+          "bech32-preview",
+          "hex",
+          "zeroize"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "zeroize 1.4.3",
+              "target": "zeroize"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.5.1"
+      },
+      "license": "Apache-2.0 OR MIT"
+    },
+    "subtle-ng 2.5.0": {
+      "name": "subtle-ng",
+      "version": "2.5.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/subtle-ng/2.5.0/download",
+          "sha256": "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "subtle_ng",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "subtle_ng",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "2.5.0"
+      },
+      "license": "BSD-3-Clause"
+    },
     "syn 1.0.105": {
       "name": "syn",
       "version": "1.0.105",
@@ -18597,19 +21321,19 @@
       },
       "license": "MIT"
     },
-    "synthez 0.2.0": {
-      "name": "synthez",
-      "version": "0.2.0",
+    "sysinfo 0.26.8": {
+      "name": "sysinfo",
+      "version": "0.26.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/synthez/0.2.0/download",
-          "sha256": "033178d0acccffc5490021657006e6a8dd586ee9dc6f7c24e7608b125e568cb1"
+          "url": "https://crates.io/api/v1/crates/sysinfo/0.26.8/download",
+          "sha256": "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "synthez",
+            "crate_name": "sysinfo",
             "crate_root": "src/lib.rs",
             "srcs": {
               "include": [
@@ -18620,7 +21344,7 @@
           }
         }
       ],
-      "library_target_name": "synthez",
+      "library_target_name": "sysinfo",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -18628,89 +21352,59 @@
         "deps": {
           "common": [
             {
-              "id": "syn 1.0.105",
-              "target": "syn"
-            },
-            {
-              "id": "synthez-core 0.2.0",
-              "target": "synthez_core"
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
             }
           ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "synthez-codegen 0.2.0",
-              "target": "synthez_codegen"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.2.0"
-      },
-      "license": "BlueOak-1.0.0"
-    },
-    "synthez-codegen 0.2.0": {
-      "name": "synthez-codegen",
-      "version": "0.2.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/synthez-codegen/0.2.0/download",
-          "sha256": "69263462a40e46960f070618e20094ce69e783a41f86e54bc75545136afd597a"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "synthez_codegen",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
+          "selects": {
+            "cfg(any(target_os = \"macos\", target_os = \"ios\"))": [
+              {
+                "id": "core-foundation-sys 0.8.3",
+                "target": "core_foundation_sys"
+              }
+            ],
+            "cfg(any(windows, target_os = \"linux\", target_os = \"android\"))": [
+              {
+                "id": "once_cell 1.16.0",
+                "target": "once_cell"
+              }
+            ],
+            "cfg(not(any(target_os = \"unknown\", target_arch = \"wasm32\")))": [
+              {
+                "id": "libc 0.2.138",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "ntapi 0.4.0",
+                "target": "ntapi"
+              },
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
           }
-        }
-      ],
-      "library_target_name": "synthez_codegen",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "syn 1.0.105",
-              "target": "syn"
-            },
-            {
-              "id": "synthez-core 0.2.0",
-              "target": "synthez_core"
-            }
-          ],
-          "selects": {}
         },
-        "edition": "2021",
-        "version": "0.2.0"
+        "edition": "2018",
+        "version": "0.26.8"
       },
-      "license": "BlueOak-1.0.0"
+      "license": "MIT"
     },
-    "synthez-core 0.2.0": {
-      "name": "synthez-core",
-      "version": "0.2.0",
+    "syslog-tracing 0.1.0": {
+      "name": "syslog-tracing",
+      "version": "0.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/synthez-core/0.2.0/download",
-          "sha256": "bb8b5a4089fe1723279f06302afda64a5dacaa11a82bcbb4d08759590d4389d9"
+          "url": "https://crates.io/api/v1/crates/syslog-tracing/0.1.0/download",
+          "sha256": "4cf9ff1f9f8e5ba220a58bbccb0375f4cabd785f96a8683b31389cefd91be747"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "synthez_core",
+            "crate_name": "syslog_tracing",
             "crate_root": "src/lib.rs",
             "srcs": {
               "include": [
@@ -18721,7 +21415,7 @@
           }
         }
       ],
-      "library_target_name": "synthez_core",
+      "library_target_name": "syslog_tracing",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -18729,33 +21423,24 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.47",
-              "target": "proc_macro2"
+              "id": "libc 0.2.138",
+              "target": "libc"
             },
             {
-              "id": "quote 1.0.21",
-              "target": "quote"
+              "id": "tracing-core 0.1.30",
+              "target": "tracing_core"
             },
             {
-              "id": "syn 1.0.105",
-              "target": "syn"
+              "id": "tracing-subscriber 0.3.16",
+              "target": "tracing_subscriber"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "sealed 0.3.0",
-              "target": "sealed"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.2.0"
+        "edition": "2018",
+        "version": "0.1.0"
       },
-      "license": "BlueOak-1.0.0"
+      "license": "MIT"
     },
     "target-lexicon 0.12.5": {
       "name": "target-lexicon",
@@ -18888,6 +21573,527 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "tendermint 0.24.0-pre.2": {
+      "name": "tendermint",
+      "version": "0.24.0-pre.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/tendermint/0.24.0-pre.2/download",
+          "sha256": "c321f411bdfb772bca0c5d9c94d8f45e3a992fae44baa60d17b99d8aaae58d04"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tendermint",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "tendermint",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "clock",
+          "default",
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.3.0",
+              "target": "bytes"
+            },
+            {
+              "id": "ed25519 1.5.2",
+              "target": "ed25519"
+            },
+            {
+              "id": "ed25519-consensus 1.2.1",
+              "target": "ed25519_consensus"
+            },
+            {
+              "id": "flex-error 0.4.4",
+              "target": "flex_error"
+            },
+            {
+              "id": "futures 0.3.25",
+              "target": "futures"
+            },
+            {
+              "id": "num-traits 0.2.15",
+              "target": "num_traits"
+            },
+            {
+              "id": "once_cell 1.16.0",
+              "target": "once_cell"
+            },
+            {
+              "id": "prost 0.10.4",
+              "target": "prost"
+            },
+            {
+              "id": "prost-types 0.10.1",
+              "target": "prost_types"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            },
+            {
+              "id": "serde_bytes 0.11.7",
+              "target": "serde_bytes"
+            },
+            {
+              "id": "serde_json 1.0.89",
+              "target": "serde_json"
+            },
+            {
+              "id": "sha2 0.9.9",
+              "target": "sha2"
+            },
+            {
+              "id": "signature 1.3.2",
+              "target": "signature"
+            },
+            {
+              "id": "subtle 2.4.1",
+              "target": "subtle"
+            },
+            {
+              "id": "subtle-encoding 0.5.1",
+              "target": "subtle_encoding"
+            },
+            {
+              "id": "tendermint-proto 0.24.0-pre.2",
+              "target": "tendermint_proto"
+            },
+            {
+              "id": "time 0.3.17",
+              "target": "time"
+            },
+            {
+              "id": "zeroize 1.4.3",
+              "target": "zeroize"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "async-trait 0.1.59",
+              "target": "async_trait"
+            },
+            {
+              "id": "serde_repr 0.1.10",
+              "target": "serde_repr"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.24.0-pre.2"
+      },
+      "license": "Apache-2.0"
+    },
+    "tendermint-abci 0.24.0-pre.2": {
+      "name": "tendermint-abci",
+      "version": "0.24.0-pre.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/tendermint-abci/0.24.0-pre.2/download",
+          "sha256": "f53ac0f0d3c1e479c35db7fe815257be95a1c9b37630b0a58292766ecf1a65e9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tendermint_abci",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "Binary": {
+            "crate_name": "kvstore-rs",
+            "crate_root": "src/application/kvstore/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "tendermint_abci",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.3.0",
+              "target": "bytes"
+            },
+            {
+              "id": "flex-error 0.4.4",
+              "target": "flex_error"
+            },
+            {
+              "id": "prost 0.10.4",
+              "target": "prost"
+            },
+            {
+              "id": "tendermint-proto 0.24.0-pre.2",
+              "target": "tendermint_proto"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.24.0-pre.2"
+      },
+      "license": "Apache-2.0"
+    },
+    "tendermint-config 0.24.0-pre.2": {
+      "name": "tendermint-config",
+      "version": "0.24.0-pre.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/tendermint-config/0.24.0-pre.2/download",
+          "sha256": "ac3eac1b63f911a7524ab44a67dcf4370dd44a3ee8f9e6524bd7be426dcfdc55"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tendermint_config",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "tendermint_config",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "flex-error 0.4.4",
+              "target": "flex_error"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.89",
+              "target": "serde_json"
+            },
+            {
+              "id": "tendermint 0.24.0-pre.2",
+              "target": "tendermint"
+            },
+            {
+              "id": "toml 0.5.9",
+              "target": "toml"
+            },
+            {
+              "id": "url 2.3.1",
+              "target": "url"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.24.0-pre.2"
+      },
+      "license": "Apache-2.0"
+    },
+    "tendermint-proto 0.24.0-pre.2": {
+      "name": "tendermint-proto",
+      "version": "0.24.0-pre.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/tendermint-proto/0.24.0-pre.2/download",
+          "sha256": "5820a81dfb85011220d2b24323870ad30a56ae446f92b170911574c79d385bc5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tendermint_proto",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "tendermint_proto",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.3.0",
+              "target": "bytes"
+            },
+            {
+              "id": "flex-error 0.4.4",
+              "target": "flex_error"
+            },
+            {
+              "id": "num-traits 0.2.15",
+              "target": "num_traits"
+            },
+            {
+              "id": "prost 0.10.4",
+              "target": "prost"
+            },
+            {
+              "id": "prost-types 0.10.1",
+              "target": "prost_types"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            },
+            {
+              "id": "serde_bytes 0.11.7",
+              "target": "serde_bytes"
+            },
+            {
+              "id": "subtle-encoding 0.5.1",
+              "target": "subtle_encoding"
+            },
+            {
+              "id": "time 0.3.17",
+              "target": "time"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "num-derive 0.3.3",
+              "target": "num_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.24.0-pre.2"
+      },
+      "license": "Apache-2.0"
+    },
+    "tendermint-rpc 0.24.0-pre.2": {
+      "name": "tendermint-rpc",
+      "version": "0.24.0-pre.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/tendermint-rpc/0.24.0-pre.2/download",
+          "sha256": "2f2a9433b4385bf54dbda310fa6df993b6777123d77caa08119361ce6fb7d628"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tendermint_rpc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "Binary": {
+            "crate_name": "tendermint-rpc",
+            "crate_root": "src/client/bin/main.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "tendermint_rpc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "async-trait",
+          "default",
+          "futures",
+          "http",
+          "http-client",
+          "hyper",
+          "hyper-proxy",
+          "hyper-rustls",
+          "tokio",
+          "tracing"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.3.0",
+              "target": "bytes"
+            },
+            {
+              "id": "flex-error 0.4.4",
+              "target": "flex_error"
+            },
+            {
+              "id": "futures 0.3.25",
+              "target": "futures"
+            },
+            {
+              "id": "getrandom 0.2.8",
+              "target": "getrandom"
+            },
+            {
+              "id": "http 0.2.8",
+              "target": "http"
+            },
+            {
+              "id": "hyper 0.14.23",
+              "target": "hyper"
+            },
+            {
+              "id": "hyper-proxy 0.9.1",
+              "target": "hyper_proxy"
+            },
+            {
+              "id": "hyper-rustls 0.22.1",
+              "target": "hyper_rustls"
+            },
+            {
+              "id": "peg 0.7.0",
+              "target": "peg"
+            },
+            {
+              "id": "pin-project 1.0.12",
+              "target": "pin_project"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            },
+            {
+              "id": "serde_bytes 0.11.7",
+              "target": "serde_bytes"
+            },
+            {
+              "id": "serde_json 1.0.89",
+              "target": "serde_json"
+            },
+            {
+              "id": "subtle 2.4.1",
+              "target": "subtle"
+            },
+            {
+              "id": "subtle-encoding 0.5.1",
+              "target": "subtle_encoding"
+            },
+            {
+              "id": "tendermint 0.24.0-pre.2",
+              "target": "tendermint"
+            },
+            {
+              "id": "tendermint-config 0.24.0-pre.2",
+              "target": "tendermint_config"
+            },
+            {
+              "id": "tendermint-proto 0.24.0-pre.2",
+              "target": "tendermint_proto"
+            },
+            {
+              "id": "thiserror 1.0.37",
+              "target": "thiserror"
+            },
+            {
+              "id": "time 0.3.17",
+              "target": "time"
+            },
+            {
+              "id": "tokio 1.23.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
+            },
+            {
+              "id": "url 2.3.1",
+              "target": "url"
+            },
+            {
+              "id": "uuid 0.8.2",
+              "target": "uuid"
+            },
+            {
+              "id": "walkdir 2.3.2",
+              "target": "walkdir"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "async-trait 0.1.59",
+              "target": "async_trait"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.24.0-pre.2"
+      },
+      "license": "Apache-2.0"
+    },
     "termcolor 1.1.3": {
       "name": "termcolor",
       "version": "1.1.3",
@@ -18982,39 +22188,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "termtree 0.4.0": {
-      "name": "termtree",
-      "version": "0.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/termtree/0.4.0/download",
-          "sha256": "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "termtree",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "termtree",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.4.0"
-      },
-      "license": "MIT"
-    },
     "textwrap 0.11.0": {
       "name": "textwrap",
       "version": "0.11.0",
@@ -19054,48 +22227,6 @@
         },
         "edition": "2015",
         "version": "0.11.0"
-      },
-      "license": "MIT"
-    },
-    "textwrap 0.12.1": {
-      "name": "textwrap",
-      "version": "0.12.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/textwrap/0.12.1/download",
-          "sha256": "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "textwrap",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "textwrap",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "unicode-width 0.1.10",
-              "target": "unicode_width"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.12.1"
       },
       "license": "MIT"
     },
@@ -19830,6 +22961,56 @@
       },
       "license": "MIT"
     },
+    "tokio-rustls 0.22.0": {
+      "name": "tokio-rustls",
+      "version": "0.22.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/tokio-rustls/0.22.0/download",
+          "sha256": "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tokio_rustls",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "tokio_rustls",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rustls 0.19.1",
+              "target": "rustls"
+            },
+            {
+              "id": "tokio 1.23.0",
+              "target": "tokio"
+            },
+            {
+              "id": "webpki 0.21.4",
+              "target": "webpki"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.22.0"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "tokio-util 0.7.4": {
       "name": "tokio-util",
       "version": "0.7.4",
@@ -20307,56 +23488,6 @@
       },
       "license": "MIT"
     },
-    "typed-builder 0.7.1": {
-      "name": "typed-builder",
-      "version": "0.7.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/typed-builder/0.7.1/download",
-          "sha256": "f85f4270f4f449a3f2c0cf2aecc8415e388a597aeacc7d55fc749c5c968c8533"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "typed_builder",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "typed_builder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.47",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.21",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.105",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.7.1"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "typenum 1.16.0": {
       "name": "typenum",
       "version": "1.16.0",
@@ -20415,6 +23546,223 @@
         ]
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "typetag 0.2.4": {
+      "name": "typetag",
+      "version": "0.2.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/typetag/0.2.4/download",
+          "sha256": "63205b6a08578f24e4288dd01692d5d215b0c2e90613089187d2e9879788ed94"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "typetag",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "typetag",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "erased-serde 0.3.24",
+              "target": "erased_serde"
+            },
+            {
+              "id": "inventory 0.3.3",
+              "target": "inventory"
+            },
+            {
+              "id": "once_cell 1.16.0",
+              "target": "once_cell"
+            },
+            {
+              "id": "serde 1.0.149",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "typetag-impl 0.2.4",
+              "target": "typetag_impl"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.2.4"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "typetag-impl 0.2.4": {
+      "name": "typetag-impl",
+      "version": "0.2.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/typetag-impl/0.2.4/download",
+          "sha256": "e5fd220a6403b4959b40a7f276a8d8d52a987b010dd8efd5c923f8f2d8933132"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "typetag_impl",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "typetag_impl",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.105",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.2.4"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "ucd-trie 0.1.5": {
+      "name": "ucd-trie",
+      "version": "0.1.5",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ucd-trie/0.1.5/download",
+          "sha256": "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ucd_trie",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "ucd_trie",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "std"
+        ],
+        "edition": "2018",
+        "version": "0.1.5"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "unicase 2.6.0": {
+      "name": "unicase",
+      "version": "2.6.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/unicase/2.6.0/download",
+          "sha256": "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "unicase",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "unicase",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "unicase 2.6.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "2.6.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "version_check 0.9.4",
+              "target": "version_check"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT/Apache-2.0"
     },
     "unicode-bidi 0.3.8": {
       "name": "unicode-bidi",
@@ -20533,39 +23881,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "unicode-segmentation 1.10.0": {
-      "name": "unicode-segmentation",
-      "version": "1.10.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-segmentation/1.10.0/download",
-          "sha256": "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "unicode_segmentation",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "unicode_segmentation",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "1.10.0"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "unicode-width 0.1.10": {
       "name": "unicode-width",
       "version": "0.1.10",
@@ -20638,6 +23953,39 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "untrusted 0.7.1": {
+      "name": "untrusted",
+      "version": "0.7.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/untrusted/0.7.1/download",
+          "sha256": "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "untrusted",
+            "crate_root": "src/untrusted.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "untrusted",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.7.1"
+      },
+      "license": "ISC"
+    },
     "url 2.3.1": {
       "name": "url",
       "version": "2.3.1",
@@ -20695,6 +24043,39 @@
         "version": "2.3.1"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "uuid 0.8.2": {
+      "name": "uuid",
+      "version": "0.8.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/uuid/0.8.2/download",
+          "sha256": "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uuid",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "uuid",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.8.2"
+      },
+      "license": "Apache-2.0 OR MIT"
     },
     "uuid 1.2.2": {
       "name": "uuid",
@@ -20878,6 +24259,140 @@
         "version": "0.8.2"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "vergen 7.4.3": {
+      "name": "vergen",
+      "version": "7.4.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/vergen/7.4.3/download",
+          "sha256": "447f9238a4553957277b3ee09d80babeae0811f1b3baefb093de1c0448437a37"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "vergen",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "vergen",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "build",
+          "cargo",
+          "default",
+          "git",
+          "git2",
+          "rustc",
+          "rustc_version",
+          "si",
+          "sysinfo",
+          "time"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.66",
+              "target": "anyhow"
+            },
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "enum-iterator 1.1.3",
+              "target": "enum_iterator"
+            },
+            {
+              "id": "git2 0.14.4",
+              "target": "git2"
+            },
+            {
+              "id": "rustc_version 0.4.0",
+              "target": "rustc_version"
+            },
+            {
+              "id": "sysinfo 0.26.8",
+              "target": "sysinfo"
+            },
+            {
+              "id": "thiserror 1.0.37",
+              "target": "thiserror"
+            },
+            {
+              "id": "time 0.3.17",
+              "target": "time"
+            },
+            {
+              "id": "vergen 7.4.3",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "getset 0.1.2",
+              "target": "getset"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "7.4.3"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.66",
+              "target": "anyhow"
+            },
+            {
+              "id": "time 0.3.17",
+              "target": "time"
+            }
+          ],
+          "selects": {}
+        },
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "rustversion 1.0.9",
+              "target": "rustversion"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "version_check 0.9.4": {
       "name": "version_check",
@@ -21602,6 +25117,7 @@
         "crate_features": [
           "Blob",
           "BlobPropertyBag",
+          "Crypto",
           "Event",
           "EventTarget",
           "File",
@@ -21957,6 +25473,111 @@
       },
       "license": "MPL-2.0"
     },
+    "webpki 0.21.4": {
+      "name": "webpki",
+      "version": "0.21.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/webpki/0.21.4/download",
+          "sha256": "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "webpki",
+            "crate_root": "src/webpki.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "webpki",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std",
+          "trust_anchor_util"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "ring 0.16.20",
+              "target": "ring"
+            },
+            {
+              "id": "untrusted 0.7.1",
+              "target": "untrusted"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.21.4"
+      },
+      "license": null
+    },
+    "webpki-roots 0.21.1": {
+      "name": "webpki-roots",
+      "version": "0.21.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/webpki-roots/0.21.1/download",
+          "sha256": "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "webpki_roots",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "Binary": {
+            "crate_name": "process_cert",
+            "crate_root": "src/bin/process_cert.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "webpki_roots",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "webpki 0.21.4",
+              "target": "webpki"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.21.1"
+      },
+      "license": "MPL-2.0"
+    },
     "wepoll-ffi 0.1.2": {
       "name": "wepoll-ffi",
       "version": "0.1.2",
@@ -22122,30 +25743,59 @@
           "**"
         ],
         "crate_features": [
+          "cfg",
+          "combaseapi",
           "consoleapi",
           "errhandlingapi",
+          "evntrace",
           "fileapi",
           "handleapi",
+          "heapapi",
           "hidclass",
           "hidpi",
           "hidusage",
+          "ifdef",
           "impl-debug",
           "impl-default",
+          "in6addr",
+          "inaddr",
+          "ioapiset",
           "libloaderapi",
+          "lmaccess",
+          "lmapibuf",
+          "lmcons",
+          "memoryapi",
           "minwinbase",
           "minwindef",
+          "netioapi",
+          "ntlsa",
+          "ntsecapi",
+          "objidl",
+          "oleauto",
+          "pdh",
+          "powerbase",
           "processenv",
+          "psapi",
+          "rpcdce",
+          "securitybaseapi",
           "setupapi",
+          "shellapi",
           "std",
+          "synchapi",
+          "sysinfoapi",
           "timezoneapi",
+          "wbemcli",
           "winbase",
           "wincon",
+          "windef",
           "winerror",
+          "winioctl",
           "winnt",
           "winreg",
           "winuser",
           "ws2ipdef",
-          "ws2tcpip"
+          "ws2tcpip",
+          "wtypesbase"
         ],
         "deps": {
           "common": [
@@ -23535,28 +27185,25 @@
   },
   "binary_crates": [
     "bindgen 0.59.2",
+    "bindgen 0.60.1",
     "cc 1.0.77",
     "clap 3.2.23",
     "minicbor 0.18.0",
-    "peg-macros 0.6.3",
-    "wait-timeout 0.2.0"
+    "peg-macros 0.7.0",
+    "tendermint-abci 0.24.0-pre.2",
+    "tendermint-rpc 0.24.0-pre.2",
+    "wait-timeout 0.2.0",
+    "webpki-roots 0.21.1"
   ],
   "workspace_members": {
-    "many 0.1.0": "src/many",
-    "many-client 0.1.0": "src/many-client",
-    "many-client-macros 0.1.0": "src/many-client-macros",
-    "many-error 0.1.0": "src/many-error",
-    "many-identity 0.1.0": "src/many-identity",
-    "many-identity-dsa 0.1.0": "src/many-identity-dsa",
-    "many-identity-hsm 0.1.0": "src/many-identity-hsm",
-    "many-identity-webauthn 0.1.0": "src/many-identity-webauthn",
-    "many-macros 0.1.0": "src/many-macros",
-    "many-migration 0.1.0": "src/many-migration",
-    "many-mock 0.1.0": "src/many-mock",
-    "many-modules 0.1.0": "src/many-modules",
-    "many-protocol 0.1.0": "src/many-protocol",
-    "many-server 0.1.0": "src/many-server",
-    "many-types 0.1.0": "src/many-types"
+    "http_proxy 0.1.0": "src/http_proxy",
+    "idstore-export 0.1.0": "src/idstore-export",
+    "kvstore 0.1.0": "src/kvstore",
+    "ledger 0.1.0": "src/ledger",
+    "ledger-db 0.1.0": "src/ledger-db",
+    "many-abci 0.1.0": "src/many-abci",
+    "many-kvstore 0.1.0": "src/many-kvstore",
+    "many-ledger 0.1.0": "src/many-ledger"
   },
   "conditions": {
     "aarch64-apple-darwin": [
@@ -23573,6 +27220,49 @@
     "cfg(all(any(target_arch = \"x86_64\", target_arch = \"aarch64\"), target_os = \"hermit\"))": [],
     "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
       "aarch64-unknown-linux-gnu"
+    ],
+    "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))": [
+      "wasm32-unknown-unknown"
+    ],
+    "cfg(all(target_arch = \"wasm32\", target_vendor = \"unknown\", target_os = \"unknown\", target_env = \"\"))": [
+      "wasm32-unknown-unknown"
+    ],
+    "cfg(all(unix, not(target_os = \"macos\")))": [
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-linux-android",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
       "aarch64-apple-darwin",
@@ -23592,6 +27282,41 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(any(target_arch = \"x86\", target_arch = \"x86_64\", all(any(target_arch = \"aarch64\", target_arch = \"arm\"), any(target_os = \"android\", target_os = \"fuchsia\", target_os = \"linux\"))))": [
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(any(target_os = \"android\", target_os = \"linux\"))": [
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-linux-android",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "x86_64-linux-android",
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"illumos\", target_os = \"netbsd\", target_os = \"openbsd\", target_os = \"solaris\"))": [
+      "i686-unknown-freebsd",
+      "x86_64-unknown-freebsd"
     ],
     "cfg(any(target_os = \"macos\", target_os = \"ios\"))": [
       "aarch64-apple-darwin",
@@ -23644,8 +27369,50 @@
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
     ],
+    "cfg(any(windows, target_os = \"linux\", target_os = \"android\"))": [
+      "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-linux-gnu"
+    ],
     "cfg(docsrs)": [],
     "cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "riscv32imc-unknown-none-elf",
+      "riscv64gc-unknown-none-elf",
+      "s390x-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(not(any(target_os = \"unknown\", target_arch = \"wasm32\")))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
       "aarch64-apple-ios-sim",

--- a/docker/e2e/Cargo.nix
+++ b/docker/e2e/Cargo.nix
@@ -30,7 +30,7 @@ args@{
   ignoreLockHash,
 }:
 let
-  nixifiedLockHash = "3c6e31c43909774bccaf4ee0f8e89828ceb50488a8c512bd7ee9ae7801da6c84";
+  nixifiedLockHash = "49203e2924afeb592081af1d85c5f55183d308891991509ad2a442c01473aed3";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
   currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
   lockHashIgnored = if ignoreLockHash
@@ -3030,7 +3030,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-client";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     features = builtins.concatLists [
       [ "default" ]
     ];
@@ -3082,7 +3082,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-client-macros";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     dependencies = {
       proc_macro2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.47" { inherit profileName; }).out;
       quote = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.21" { inherit profileName; }).out;
@@ -3098,7 +3098,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-error";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     features = builtins.concatLists [
       [ "default" ]
       [ "minicbor" ]
@@ -3119,7 +3119,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-identity";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     features = builtins.concatLists [
       [ "coset" ]
       [ "default" ]
@@ -3153,7 +3153,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-identity-dsa";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     features = builtins.concatLists [
       [ "coset" ]
       [ "default" ]
@@ -3195,7 +3195,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-identity-hsm";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     dependencies = {
       asn1 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".asn1."0.10.0" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
@@ -3221,7 +3221,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-identity-webauthn";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     features = builtins.concatLists [
       [ "default" ]
       [ "identity" ]
@@ -3366,7 +3366,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-macros";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     dependencies = {
       inflections = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".inflections."1.1.1" { inherit profileName; }).out;
       proc_macro2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.47" { inherit profileName; }).out;
@@ -3385,7 +3385,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-migration";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     dependencies = {
       many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
@@ -3404,7 +3404,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-modules";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     dependencies = {
       async_trait = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".async-trait."0.1.59" { profileName = "__noProfile"; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
@@ -3430,7 +3430,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-protocol";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     dependencies = {
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.1" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
@@ -3460,7 +3460,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-server";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     features = builtins.concatLists [
       [ "default" ]
     ];
@@ -3518,7 +3518,7 @@ in
       url = https://github.com/liftedinit/many-rs.git;
       name = "many-types";
       version = "0.1.0";
-      rev = "cfabad4a057d56a9fb6e48e8f37de6a865227e1f";};
+      rev = "b649ee3709197dae3fdff883146d9ea6a13551c7";};
     dependencies = {
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.20.0" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;


### PR DESCRIPTION
This commit includes a workaround for a `rust_register_toolchains` regression between 0.14 and 0.15