### PR TITLE
Fix duplicate ticker and subresource overwrite/exhaustion

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "base32",
  "coset",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "asn1 0.8.7",
  "base32",
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "asn1 0.10.0",
  "coset",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "authenticator-ctap2-2021",
  "base64 0.13.1",
@@ -2765,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "many-error",
  "minicbor",
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "async-trait",
  "coset",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "anyhow",
  "asn1 0.11.0",
@@ -2885,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "base64 0.20.0",
  "coset",
@@ -5387,15 +5387,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "many"
-version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
-
-
-[[patch.unused]]
-name = "many-mock"
-version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
-

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "base32",
  "coset",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "asn1 0.8.7",
  "base32",
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "asn1 0.10.0",
  "coset",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "authenticator-ctap2-2021",
  "base64 0.13.1",
@@ -2765,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "many-error",
  "minicbor",
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "async-trait",
  "coset",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "anyhow",
  "asn1 0.11.0",
@@ -2885,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "base64 0.20.0",
  "coset",
@@ -5387,3 +5387,15 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "many"
+version = "0.1.0"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+
+
+[[patch.unused]]
+name = "many-mock"
+version = "0.1.0"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "base32",
  "coset",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "asn1 0.8.7",
  "base32",
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "asn1 0.10.0",
  "coset",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "authenticator-ctap2-2021",
  "base64 0.13.1",
@@ -2765,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "many-error",
  "minicbor",
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "async-trait",
  "coset",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "anyhow",
  "asn1 0.11.0",
@@ -2885,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/liftedinit/many-rs.git?rev=ce03b88dea51232ca578d19d52cfc263cfc4080b#ce03b88dea51232ca578d19d52cfc263cfc4080b"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
 dependencies = [
  "base64 0.20.0",
  "coset",
@@ -5412,3 +5412,13 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "many"
+version = "0.1.0"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+
+[[patch.unused]]
+name = "many-mock"
+version = "0.1.0"
+source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "many-client-macros"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "many-error"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "minicbor",
  "num-derive",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "many-identity"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "base32",
  "coset",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "many-identity-dsa"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "asn1 0.8.7",
  "base32",
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "many-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "asn1 0.10.0",
  "coset",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "many-identity-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "authenticator-ctap2-2021",
  "base64 0.13.1",
@@ -2765,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "many-migration"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "many-error",
  "minicbor",
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "many-modules"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "async-trait",
  "coset",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "many-protocol"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "base64 0.13.1",
  "coset",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "many-server"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "anyhow",
  "asn1 0.11.0",
@@ -2885,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "many-types"
 version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
+source = "git+https://github.com/liftedinit/many-rs.git?rev=0db81ac956bc68c5c43f3f16ede9435ecceb4801#0db81ac956bc68c5c43f3f16ede9435ecceb4801"
 dependencies = [
  "base64 0.20.0",
  "coset",
@@ -5412,13 +5412,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "many"
-version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"
-
-[[patch.unused]]
-name = "many-mock"
-version = "0.1.0"
-source = "git+https://github.com/fmorency/many-rs.git?branch=pub_max_subresource_id#d550236dda05937ddecf042bcda71b86e17ed0ee"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,23 @@ incremental = false
 #many-server = { path = "../many-rs/src/many-server" }
 #many-types = { path = "../many-rs/src/many-types" }
 
+[patch."https://github.com/liftedinit/many-rs.git"]
+many = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-client = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-client-macros = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-error = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-identity = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-identity-dsa = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-identity-hsm = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-identity-webauthn = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-macros = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-migration = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-mock = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-modules = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-protocol = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-server = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+many-types = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
+
 [patch.crates-io]
 ciborium = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }
 ciborium-io = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,23 +38,6 @@ incremental = false
 #many-server = { path = "../many-rs/src/many-server" }
 #many-types = { path = "../many-rs/src/many-types" }
 
-[patch."https://github.com/liftedinit/many-rs.git"]
-many = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-client = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-client-macros = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-error = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-identity = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-identity-dsa = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-identity-hsm = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-identity-webauthn = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-macros = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-migration = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-mock = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-modules = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-protocol = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-server = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-many-types = { git = "https://github.com/fmorency/many-rs.git", branch = "pub_max_subresource_id" }
-
 [patch.crates-io]
 ciborium = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }
 ciborium-io = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "65db024bdba42cc6a109fc102408caf0f6ea6f2e25f8ca45c0ebb06b3e4821b6",
+  "checksum": "dbb11fa08f0bd8049c27031743dd821be7a69319b20ad829e8749a353e680b02",
   "crates": {
     "aes 0.7.5": {
       "name": "aes",
@@ -13451,9 +13451,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-client"
         }
@@ -13644,9 +13644,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-client-macros"
         }
@@ -13697,9 +13697,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-error"
         }
@@ -13763,9 +13763,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-identity"
         }
@@ -13864,9 +13864,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-identity-dsa"
         }
@@ -13998,9 +13998,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-identity-hsm"
         }
@@ -14091,9 +14091,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-identity-webauthn"
         }
@@ -14825,9 +14825,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-macros"
         }
@@ -14890,9 +14890,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-migration"
         }
@@ -14955,9 +14955,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-modules"
         }
@@ -15060,9 +15060,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-protocol"
         }
@@ -15174,9 +15174,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-server"
         }
@@ -15391,9 +15391,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/liftedinit/many-rs.git",
+          "remote": "https://github.com/fmorency/many-rs.git",
           "commitish": {
-            "Rev": "ce03b88dea51232ca578d19d52cfc263cfc4080b"
+            "Branch": "pub_max_subresource_id"
           },
           "strip_prefix": "src/many-types"
         }

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "dbb11fa08f0bd8049c27031743dd821be7a69319b20ad829e8749a353e680b02",
+  "checksum": "1e6929ba0ff21e744b6772d18e4b1c6f6820fe4c299425834711cd471b22d497",
   "crates": {
     "aes 0.7.5": {
       "name": "aes",
@@ -13451,9 +13451,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-client"
         }
@@ -13644,9 +13644,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-client-macros"
         }
@@ -13697,9 +13697,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-error"
         }
@@ -13763,9 +13763,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-identity"
         }
@@ -13864,9 +13864,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-identity-dsa"
         }
@@ -13998,9 +13998,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-identity-hsm"
         }
@@ -14091,9 +14091,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-identity-webauthn"
         }
@@ -14825,9 +14825,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-macros"
         }
@@ -14890,9 +14890,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-migration"
         }
@@ -14955,9 +14955,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-modules"
         }
@@ -15060,9 +15060,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-protocol"
         }
@@ -15174,9 +15174,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-server"
         }
@@ -15391,9 +15391,9 @@
       "version": "0.1.0",
       "repository": {
         "Git": {
-          "remote": "https://github.com/fmorency/many-rs.git",
+          "remote": "https://github.com/liftedinit/many-rs.git",
           "commitish": {
-            "Branch": "pub_max_subresource_id"
+            "Rev": "0db81ac956bc68c5c43f3f16ede9435ecceb4801"
           },
           "strip_prefix": "src/many-types"
         }

--- a/docker/e2e/Cargo.nix
+++ b/docker/e2e/Cargo.nix
@@ -33,7 +33,7 @@ args@{
   ignoreLockHash,
 }:
 let
-  nixifiedLockHash = "db314a84f9ce6190cc3ec30c8c64238ddece91c8c5bedcb4b783e00419933023";
+  nixifiedLockHash = "1a87713c57153723006a6ff81a6d4c09eb0eb6664a955f680cc776ac5c9a8c9e";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
   currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
   lockHashIgnored = if ignoreLockHash
@@ -2766,11 +2766,11 @@ in
     dependencies = {
       clap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.23" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       many_kvstore = (rustPackages."unknown".many-kvstore."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       new_mime_guess = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".new_mime_guess."4.0.1" { inherit profileName; }).out;
       syslog_tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syslog-tracing."0.1.0" { inherit profileName; }).out;
@@ -3144,13 +3144,13 @@ in
       clap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.23" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
       indicatif = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indicatif."0.16.2" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       syslog_tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syslog-tracing."0.1.0" { inherit profileName; }).out;
       tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.24.2" { inherit profileName; }).out;
@@ -3186,14 +3186,14 @@ in
       indicatif = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indicatif."0.16.2" { inherit profileName; }).out;
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_identity_hsm = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-hsm."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity_hsm = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-hsm."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       mime_guess = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".mime_guess."2.0.4" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
@@ -3216,8 +3216,8 @@ in
     dependencies = {
       clap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.23" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."2.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
     };
@@ -3413,15 +3413,15 @@ in
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       json5 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".json5."0.4.1" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_identity_webauthn = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity_webauthn = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_integer = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-integer."0.1.45" { inherit profileName; }).out;
       reqwest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.14" { inherit profileName; }).out;
@@ -3442,16 +3442,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-client";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-client";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     features = builtins.concatLists [
       [ "default" ]
     ];
@@ -3469,13 +3468,13 @@ in
       fixed = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.21.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_client_macros = (buildRustPackages."git+https://github.com/fmorency/many-rs.git".many-client-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client_macros = (buildRustPackages."git+https://github.com/liftedinit/many-rs.git".many-client-macros."0.1.0" { profileName = "__noProfile"; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
@@ -3495,16 +3494,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-client-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-client-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-client-macros";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-client-macros";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     dependencies = {
       proc_macro2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.50" { inherit profileName; }).out;
       quote = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.23" { inherit profileName; }).out;
@@ -3512,16 +3510,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-error";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-error";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     features = builtins.concatLists [
       [ "default" ]
       [ "minicbor" ]
@@ -3534,16 +3531,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-identity";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     features = builtins.concatLists [
       [ "coset" ]
       [ "default" ]
@@ -3557,7 +3553,7 @@ in
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       crc_any = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".crc-any."2.4.3" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.152" { inherit profileName; }).out;
@@ -3569,16 +3565,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity-dsa";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-identity-dsa";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     features = builtins.concatLists [
       [ "coset" ]
       [ "default" ]
@@ -3596,8 +3591,8 @@ in
       ed25519 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".ed25519."1.5.3" { inherit profileName; }).out;
       ed25519_dalek = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".ed25519-dalek."1.0.1" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       p256 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".p256."0.9.0" { inherit profileName; }).out;
@@ -3612,25 +3607,24 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-identity-hsm."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-identity-hsm."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity-hsm";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-identity-hsm";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     dependencies = {
       asn1 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".asn1."0.10.0" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       cryptoki = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cryptoki."0.3.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       p256 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".p256."0.9.0" { inherit profileName; }).out;
       sha2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha2."0.10.6" { inherit profileName; }).out;
@@ -3639,16 +3633,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-identity-webauthn."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-identity-webauthn."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity-webauthn";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-identity-webauthn";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     features = builtins.concatLists [
       [ "default" ]
       [ "identity" ]
@@ -3658,12 +3651,12 @@ in
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.1" { inherit profileName; }).out;
       base64urlsafedata = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64urlsafedata."0.1.2" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       rand = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand."0.8.5" { inherit profileName; }).out;
@@ -3692,13 +3685,13 @@ in
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       json5 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".json5."0.4.1" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."2.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
@@ -3714,8 +3707,8 @@ in
       tracing_subscriber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.16" { inherit profileName; }).out;
     };
     devDependencies = {
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       tempfile = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tempfile."3.3.0" { inherit profileName; }).out;
     };
@@ -3747,15 +3740,15 @@ in
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       json5 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".json5."0.4.1" { inherit profileName; }).out;
       linkme = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".linkme."0.3.7" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_identity_webauthn = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
-      many_migration = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity_webauthn = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
+      many_migration = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."2.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
@@ -3776,14 +3769,14 @@ in
     };
     devDependencies = {
       cucumber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cucumber."0.17.0" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       many_ledger = (rustPackages."unknown".many-ledger."0.1.0" { inherit profileName; }).out;
       many_ledger_test_macros = (buildRustPackages."unknown".many-ledger-test-macros."0.1.0" { profileName = "__noProfile"; }).out;
       many_ledger_test_utils = (rustPackages."unknown".many-ledger-test-utils."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       proptest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proptest."1.0.0" { inherit profileName; }).out;
       tempfile = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tempfile."3.3.0" { inherit profileName; }).out;
@@ -3814,15 +3807,15 @@ in
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       cucumber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cucumber."0.17.0" { inherit profileName; }).out;
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       many_ledger = (rustPackages."unknown".many-ledger."0.1.0" { inherit profileName; }).out;
       many_ledger_test_macros = (buildRustPackages."unknown".many-ledger-test-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_migration = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_migration = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."2.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
@@ -3833,16 +3826,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-macros";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-macros";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     dependencies = {
       inflections = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".inflections."1.1.1" { inherit profileName; }).out;
       proc_macro2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.50" { inherit profileName; }).out;
@@ -3853,18 +3845,17 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-migration."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-migration."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-migration";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-migration";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     dependencies = {
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.152" { inherit profileName; }).out;
       serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.91" { inherit profileName; }).out;
@@ -3873,16 +3864,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-modules";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-modules";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     features = builtins.concatLists [
       [ "cucumber" ]
     ];
@@ -3891,11 +3881,11 @@ in
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       derive_builder = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".derive_builder."0.11.2" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_macros = (buildRustPackages."git+https://github.com/fmorency/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_macros = (buildRustPackages."git+https://github.com/liftedinit/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_enum = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num_enum."0.5.7" { inherit profileName; }).out;
@@ -3904,24 +3894,23 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-protocol";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-protocol";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     dependencies = {
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.1" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       derive_builder = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".derive_builder."0.10.2" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
@@ -3935,16 +3924,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-server";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-server";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     features = builtins.concatLists [
       [ "default" ]
     ];
@@ -3964,12 +3952,12 @@ in
       fixed = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.21.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_macros = (buildRustPackages."git+https://github.com/fmorency/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_macros = (buildRustPackages."git+https://github.com/liftedinit/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
+      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
@@ -3994,16 +3982,15 @@ in
     };
   });
   
-  "git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-types";
     version = "0.1.0";
-    registry = "git+https://github.com/fmorency/many-rs.git";
+    registry = "git+https://github.com/liftedinit/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/fmorency/many-rs.git;
+      url = https://github.com/liftedinit/many-rs.git;
       name = "many-types";
       version = "0.1.0";
-      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
-      ref = "pub_max_subresource_id";};
+      rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801";};
     features = builtins.concatLists [
       [ "cucumber" ]
     ];
@@ -4012,8 +3999,8 @@ in
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       fixed = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.21.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;

--- a/docker/e2e/Cargo.nix
+++ b/docker/e2e/Cargo.nix
@@ -33,7 +33,7 @@ args@{
   ignoreLockHash,
 }:
 let
-  nixifiedLockHash = "55687ddcaa22f264139196a9ddbdb384942d458a5ea980abd8be31922d517230";
+  nixifiedLockHash = "db314a84f9ce6190cc3ec30c8c64238ddece91c8c5bedcb4b783e00419933023";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
   currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
   lockHashIgnored = if ignoreLockHash
@@ -2766,11 +2766,11 @@ in
     dependencies = {
       clap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.23" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       many_kvstore = (rustPackages."unknown".many-kvstore."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       new_mime_guess = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".new_mime_guess."4.0.1" { inherit profileName; }).out;
       syslog_tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syslog-tracing."0.1.0" { inherit profileName; }).out;
@@ -3144,13 +3144,13 @@ in
       clap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.23" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
       indicatif = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indicatif."0.16.2" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       syslog_tracing = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".syslog-tracing."0.1.0" { inherit profileName; }).out;
       tokio = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tokio."1.24.2" { inherit profileName; }).out;
@@ -3186,14 +3186,14 @@ in
       indicatif = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".indicatif."0.16.2" { inherit profileName; }).out;
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_identity_hsm = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-hsm."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity_hsm = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-hsm."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       mime_guess = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".mime_guess."2.0.4" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
@@ -3216,8 +3216,8 @@ in
     dependencies = {
       clap = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.23" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."2.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
     };
@@ -3413,15 +3413,15 @@ in
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       json5 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".json5."0.4.1" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_identity_webauthn = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity_webauthn = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_integer = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-integer."0.1.45" { inherit profileName; }).out;
       reqwest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".reqwest."0.11.14" { inherit profileName; }).out;
@@ -3442,15 +3442,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-client";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-client";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     features = builtins.concatLists [
       [ "default" ]
     ];
@@ -3468,13 +3469,13 @@ in
       fixed = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.21.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_client_macros = (buildRustPackages."git+https://github.com/liftedinit/many-rs.git".many-client-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_client_macros = (buildRustPackages."git+https://github.com/fmorency/many-rs.git".many-client-macros."0.1.0" { profileName = "__noProfile"; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
@@ -3494,15 +3495,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-client-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-client-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-client-macros";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-client-macros";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     dependencies = {
       proc_macro2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.50" { inherit profileName; }).out;
       quote = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.23" { inherit profileName; }).out;
@@ -3510,15 +3512,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-error";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-error";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     features = builtins.concatLists [
       [ "default" ]
       [ "minicbor" ]
@@ -3531,15 +3534,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-identity";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     features = builtins.concatLists [
       [ "coset" ]
       [ "default" ]
@@ -3553,7 +3557,7 @@ in
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       crc_any = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".crc-any."2.4.3" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.152" { inherit profileName; }).out;
@@ -3565,15 +3569,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity-dsa";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-identity-dsa";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     features = builtins.concatLists [
       [ "coset" ]
       [ "default" ]
@@ -3591,8 +3596,8 @@ in
       ed25519 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".ed25519."1.5.3" { inherit profileName; }).out;
       ed25519_dalek = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".ed25519-dalek."1.0.1" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       p256 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".p256."0.9.0" { inherit profileName; }).out;
@@ -3607,24 +3612,25 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-identity-hsm."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-identity-hsm."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity-hsm";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-identity-hsm";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     dependencies = {
       asn1 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".asn1."0.10.0" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       cryptoki = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cryptoki."0.3.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       p256 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".p256."0.9.0" { inherit profileName; }).out;
       sha2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".sha2."0.10.6" { inherit profileName; }).out;
@@ -3633,15 +3639,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-identity-webauthn."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-identity-webauthn."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-identity-webauthn";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-identity-webauthn";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     features = builtins.concatLists [
       [ "default" ]
       [ "identity" ]
@@ -3651,12 +3658,12 @@ in
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.1" { inherit profileName; }).out;
       base64urlsafedata = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64urlsafedata."0.1.2" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       rand = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand."0.8.5" { inherit profileName; }).out;
@@ -3685,13 +3692,13 @@ in
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       json5 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".json5."0.4.1" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."2.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
@@ -3707,8 +3714,8 @@ in
       tracing_subscriber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tracing-subscriber."0.3.16" { inherit profileName; }).out;
     };
     devDependencies = {
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       tempfile = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tempfile."3.3.0" { inherit profileName; }).out;
     };
@@ -3740,15 +3747,15 @@ in
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
       json5 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".json5."0.4.1" { inherit profileName; }).out;
       linkme = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".linkme."0.3.7" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
-      many_identity_webauthn = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
-      many_migration = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_server = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_identity_webauthn = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-webauthn."0.1.0" { inherit profileName; }).out;
+      many_migration = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_server = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."2.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
@@ -3769,14 +3776,14 @@ in
     };
     devDependencies = {
       cucumber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cucumber."0.17.0" { inherit profileName; }).out;
-      many_client = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_client = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-client."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       many_ledger = (rustPackages."unknown".many-ledger."0.1.0" { inherit profileName; }).out;
       many_ledger_test_macros = (buildRustPackages."unknown".many-ledger-test-macros."0.1.0" { profileName = "__noProfile"; }).out;
       many_ledger_test_utils = (rustPackages."unknown".many-ledger-test-utils."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
       proptest = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proptest."1.0.0" { inherit profileName; }).out;
       tempfile = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".tempfile."3.3.0" { inherit profileName; }).out;
@@ -3807,15 +3814,15 @@ in
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       cucumber = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".cucumber."0.17.0" { inherit profileName; }).out;
       itertools = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".itertools."0.10.5" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_identity_dsa = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_identity_dsa = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity-dsa."0.1.0" { inherit profileName; }).out;
       many_ledger = (rustPackages."unknown".many-ledger."0.1.0" { inherit profileName; }).out;
       many_ledger_test_macros = (buildRustPackages."unknown".many-ledger-test-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_migration = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_migration = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-migration."0.1.0" { inherit profileName; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       merk = (rustPackages."git+https://github.com/liftedinit/merk.git".merk."2.0.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       once_cell = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.17.0" { inherit profileName; }).out;
@@ -3826,15 +3833,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-macros."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-macros";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-macros";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     dependencies = {
       inflections = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".inflections."1.1.1" { inherit profileName; }).out;
       proc_macro2 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.50" { inherit profileName; }).out;
@@ -3845,17 +3853,18 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-migration."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-migration."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-migration";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-migration";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     dependencies = {
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       serde = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.152" { inherit profileName; }).out;
       serde_json = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.91" { inherit profileName; }).out;
@@ -3864,15 +3873,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-modules";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-modules";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     features = builtins.concatLists [
       [ "cucumber" ]
     ];
@@ -3881,11 +3891,11 @@ in
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       derive_builder = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".derive_builder."0.11.2" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_macros = (buildRustPackages."git+https://github.com/liftedinit/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_macros = (buildRustPackages."git+https://github.com/fmorency/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_enum = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num_enum."0.5.7" { inherit profileName; }).out;
@@ -3894,23 +3904,24 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-protocol";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-protocol";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     dependencies = {
       base64 = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".base64."0.13.1" { inherit profileName; }).out;
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       derive_builder = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".derive_builder."0.10.2" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
@@ -3924,15 +3935,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-server."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-server."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-server";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-server";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     features = builtins.concatLists [
       [ "default" ]
     ];
@@ -3952,12 +3964,12 @@ in
       fixed = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.21.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
       lazy_static = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
-      many_macros = (buildRustPackages."git+https://github.com/liftedinit/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
-      many_modules = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
-      many_protocol = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
-      many_types = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_macros = (buildRustPackages."git+https://github.com/fmorency/many-rs.git".many-macros."0.1.0" { profileName = "__noProfile"; }).out;
+      many_modules = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-modules."0.1.0" { inherit profileName; }).out;
+      many_protocol = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-protocol."0.1.0" { inherit profileName; }).out;
+      many_types = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;
@@ -3982,15 +3994,16 @@ in
     };
   });
   
-  "git+https://github.com/liftedinit/many-rs.git".many-types."0.1.0" = overridableMkRustCrate (profileName: rec {
+  "git+https://github.com/fmorency/many-rs.git".many-types."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "many-types";
     version = "0.1.0";
-    registry = "git+https://github.com/liftedinit/many-rs.git";
+    registry = "git+https://github.com/fmorency/many-rs.git";
     src = fetchCrateGit {
-      url = https://github.com/liftedinit/many-rs.git;
+      url = https://github.com/fmorency/many-rs.git;
       name = "many-types";
       version = "0.1.0";
-      rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b";};
+      rev = "d550236dda05937ddecf042bcda71b86e17ed0ee";
+      ref = "pub_max_subresource_id";};
     features = builtins.concatLists [
       [ "cucumber" ]
     ];
@@ -3999,8 +4012,8 @@ in
       coset = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".coset."0.3.3" { inherit profileName; }).out;
       fixed = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".fixed."1.21.0" { inherit profileName; }).out;
       hex = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.4.3" { inherit profileName; }).out;
-      many_error = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
-      many_identity = (rustPackages."git+https://github.com/liftedinit/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
+      many_error = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-error."0.1.0" { inherit profileName; }).out;
+      many_identity = (rustPackages."git+https://github.com/fmorency/many-rs.git".many-identity."0.1.0" { inherit profileName; }).out;
       minicbor = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".minicbor."0.18.0" { inherit profileName; }).out;
       num_bigint = (rustPackages."registry+https://github.com/rust-lang/crates.io-index".num-bigint."0.4.3" { inherit profileName; }).out;
       num_derive = (buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".num-derive."0.3.3" { profileName = "__noProfile"; }).out;

--- a/docker/e2e/Makefile.ledger
+++ b/docker/e2e/Makefile.ledger
@@ -1,6 +1,7 @@
 LEDGER_TAG ?= "latest"
 MIGRATIONS ?=
 ALLOW_ADDRS ?= false
+STATE ?= "ledger_state.json"
 
 ENABLE_MIGRATIONS := false
 ifdef MIGRATIONS
@@ -65,7 +66,7 @@ endif
 	docker run --user $$(id -u) -it --rm -v ${PWD}/$@/:/export alpine/openssl genpkey -algorithm Ed25519 -out /export/ledger.pem
 	docker run --user $$(id -u) -it --rm -v ${PWD}/$@/:/export alpine/openssl genpkey -algorithm Ed25519 -out /export/abci.pem
 	mkdir -p "$@/persistent-ledger"
-	cp ledger_state.json $@/ledger_state.json5
+	cp "$(STATE)" $@/ledger_state.json5
 
 .PHONY: start-nodes
 start-nodes: many/many-ledger many/many-abci genfiles-ledger/generate-tendermint-e2e-config genfiles-ledger/docker-compose.json

--- a/docker/e2e/docker-compose-ledger.jsonnet
+++ b/docker/e2e/docker-compose-ledger.jsonnet
@@ -8,7 +8,8 @@ local generate_balance_flags(id_with_balances="", token="mqbfbahksdwaqeenayy2gxk
              local g = std.split(x, ":");
              local id = g[0];
              local amount = if std.length(g) > 1 then g[1] else "10000000000";
-             "--balance-only-for-testing=" + std.join(":", [id, amount, token])
+             local symbol = if std.length(g) > 1 then g[2] else token;
+             "--balance-only-for-testing=" + std.join(":", [id, amount, symbol])
         ),
         std.split(id_with_balances, " ")
     );

--- a/docker/e2e/docker-compose-ledger.jsonnet
+++ b/docker/e2e/docker-compose-ledger.jsonnet
@@ -8,7 +8,7 @@ local generate_balance_flags(id_with_balances="", token="mqbfbahksdwaqeenayy2gxk
              local g = std.split(x, ":");
              local id = g[0];
              local amount = if std.length(g) > 1 then g[1] else "10000000000";
-             local symbol = if std.length(g) > 1 then g[2] else token;
+             local symbol = if std.length(g) > 2 then g[2] else token;
              "--balance-only-for-testing=" + std.join(":", [id, amount, symbol])
         ),
         std.split(id_with_balances, " ")

--- a/src/http_proxy/Cargo.toml
+++ b/src/http_proxy/Cargo.toml
@@ -19,11 +19,11 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
 many-kvstore = { path = "../many-kvstore" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
 new_mime_guess = "4.0.0"
 syslog-tracing = "0.1"
 tiny_http = "0.11.0"

--- a/src/kvstore/Cargo.toml
+++ b/src/kvstore/Cargo.toml
@@ -20,13 +20,13 @@ clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 indicatif = "0.16.2"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["ed25519", "ecdsa"] }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["ed25519", "ecdsa"] }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
 syslog-tracing = "0.1"
 tracing = "0.1.29"
 tracing-subscriber = "0.3"

--- a/src/ledger-db/Cargo.toml
+++ b/src/ledger-db/Cargo.toml
@@ -19,6 +19,6 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "3d509c8efd3a68d85a5769f7fff300e10290d137" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
 minicbor = "0.18.0"

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -26,14 +26,14 @@ lazy_static = "1.4.0"
 mime_guess = "2.0.4"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
 num-bigint = "0.4.3"
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["serde"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["ed25519", "ecdsa"]  }
-many-identity-hsm = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["serde"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["ed25519", "ecdsa"]  }
+many-identity-hsm = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
 regex = "1.5.4"
 ring = "0.16.20"
 rpassword = "6.0"

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -26,15 +26,15 @@ itertools = "0.10.5"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
 num-integer = "0.1.45"
 reqwest = "0.11.11"
 sha2 = "0.10.1"

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -27,13 +27,13 @@ json5 = "0.4.1"
 lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["default", "serde"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["ed25519", "ecdsa"]  }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["default", "serde"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["ed25519", "ecdsa"]  }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
 serde = "1.0.130"
 serde_json = "1.0.72"
 sha3 = "0.10.4"
@@ -47,8 +47,8 @@ tracing-subscriber = "0.3"
 
 [dev-dependencies]
 once_cell = "1.14.0"
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["default", "serde", "testing"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = [ "ed25519", "testing" ] }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["default", "serde", "testing"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = [ "ed25519", "testing" ] }
 tempfile = "3.3.0"
 
 [build-dependencies]

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -32,15 +32,15 @@ linkme = { version = "0.3.5", features = ["used_linker"] }
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["default", "serde"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["ed25519", "ecdsa"]  }
-many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-migration = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["default", "serde"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["ed25519", "ecdsa"]  }
+many-identity-webauthn = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-migration = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-server = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
 rand = "0.8"
 serde = "1.0.130"
 serde_json = "1.0.72"
@@ -58,11 +58,11 @@ typetag = "0.2.3"
 [dev-dependencies]
 cucumber = { version = "0.17.0", features = ["libtest"] }
 once_cell = "1.12"
-many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["default", "serde", "testing"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = [ "ed25519", "testing" ] }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["cucumber"] }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["cucumber"] }
+many-client = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["default", "serde", "testing"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = [ "ed25519", "testing" ] }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["cucumber"] }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["cucumber"] }
 many-ledger = { path = ".", features = ["balance_testing", "migration_testing", "disable_token_sender_check"]}
 proptest = "1"
 tempfile = "3.3.0"

--- a/src/many-ledger/src/error.rs
+++ b/src/many-ledger/src/error.rs
@@ -25,7 +25,8 @@ define_attribute_many_error!(
         1: pub fn token_info_not_found(symbol) => "Token information not found in persistent storage: {symbol}.",
         2: pub fn ext_info_not_found(symbol) => "Token extended information not found in persistent storage: {symbol}.",
         3: pub fn invalid_sender() => "Unauthorised Token endpoints sender.",
-        4: pub fn ticker_exists(ticker) => "Token ticker already exists on this network: {ticker}."
+        4: pub fn ticker_exists(ticker) => "Token ticker already exists on this network: {ticker}.",
+        5: pub fn subresource_exhausted(key) => "Subresources are exhausted for: {key}.",
     }
 );
 

--- a/src/many-ledger/src/error.rs
+++ b/src/many-ledger/src/error.rs
@@ -25,6 +25,7 @@ define_attribute_many_error!(
         1: pub fn token_info_not_found(symbol) => "Token information not found in persistent storage: {symbol}.",
         2: pub fn ext_info_not_found(symbol) => "Token extended information not found in persistent storage: {symbol}.",
         3: pub fn invalid_sender() => "Unauthorised Token endpoints sender.",
+        4: pub fn ticker_exists(ticker) => "Token ticker already exists on this network: {ticker}."
     }
 );
 

--- a/src/many-ledger/src/json.rs
+++ b/src/many-ledger/src/json.rs
@@ -147,7 +147,16 @@ pub struct InitialStateJson {
 impl InitialStateJson {
     pub fn read<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {
         let content = std::fs::read_to_string(path.as_ref()).map_err(Box::new)?;
-        let s = json5::from_str(&content).map_err(Box::new)?;
+        let s: InitialStateJson = json5::from_str(&content).map_err(Box::new)?;
+        if let (Some(token_identity), Some(account_identity)) =
+            (s.token_identity, s.account_identity)
+        {
+            if token_identity == account_identity {
+                return Err(Box::new(ManyError::unknown(
+                    "Token and account identities must be different.",
+                )));
+            }
+        }
         Ok(s)
     }
 

--- a/src/many-ledger/src/storage/account.rs
+++ b/src/many-ledger/src/storage/account.rs
@@ -102,7 +102,7 @@ impl LedgerStorage {
         mut account: account::Account,
         add_event: bool,
     ) -> Result<Address, ManyError> {
-        let id = self.get_next_subresource(ACCOUNT_IDENTITY_ROOT, ACCOUNT_SUBRESOURCE_ID_ROOT)?;
+        let id = self.get_next_subresource(ACCOUNT_IDENTITY_ROOT)?;
 
         // The account MUST own itself.
         account.add_role(&id, account::Role::Owner);

--- a/src/many-ledger/src/storage/ledger_tokens.rs
+++ b/src/many-ledger/src/storage/ledger_tokens.rs
@@ -2,6 +2,7 @@ use crate::error;
 use crate::migration::tokens::TOKEN_MIGRATION;
 use crate::storage::iterator::LedgerIterator;
 use crate::storage::{key_for_account_balance, LedgerStorage, IDENTITY_ROOT, SYMBOLS_ROOT};
+use itertools::Itertools;
 use many_error::ManyError;
 use many_identity::Address;
 use many_modules::events::EventInfo;
@@ -360,6 +361,9 @@ impl LedgerStorage {
                 info.summary.name = name.clone();
             }
             if let Some(ticker) = ticker.as_ref() {
+                if self.get_symbols_and_tickers()?.values().contains(ticker) {
+                    return Err(error::ticker_exists(ticker));
+                };
                 self.update_symbols(symbol, ticker.clone())?;
                 info.summary.ticker = ticker.clone();
             }

--- a/src/many-ledger/src/storage/ledger_tokens.rs
+++ b/src/many-ledger/src/storage/ledger_tokens.rs
@@ -1,7 +1,10 @@
 use crate::error;
 use crate::migration::tokens::TOKEN_MIGRATION;
 use crate::storage::iterator::LedgerIterator;
-use crate::storage::{key_for_account_balance, LedgerStorage, IDENTITY_ROOT, SYMBOLS_ROOT};
+use crate::storage::{
+    key_for_account_balance, key_for_subresource_counter, LedgerStorage, IDENTITY_ROOT,
+    SYMBOLS_ROOT,
+};
 use itertools::Itertools;
 use many_error::ManyError;
 use many_identity::Address;
@@ -20,7 +23,6 @@ use std::str::FromStr;
 
 pub const SYMBOLS_ROOT_DASH: &str = const_format::concatcp!(SYMBOLS_ROOT, "/");
 pub const TOKEN_IDENTITY_ROOT: &str = "/config/token_identity";
-pub const TOKEN_SUBRESOURCE_COUNTER_ROOT: &str = "/config/token_subresource_id";
 
 pub fn key_for_symbol(symbol: &Symbol) -> String {
     format!("/config/symbols/{symbol}")
@@ -111,7 +113,6 @@ impl LedgerStorage {
             }
 
             let mut batch: Vec<BatchEntry> = Vec::new();
-
             for (k, meta) in symbols_meta.into_iter() {
                 let total_supply = total_supply[&k].clone(); // Safe
                 let ticker = symbols[&k].clone(); // Safe
@@ -129,20 +130,24 @@ impl LedgerStorage {
                     Op::Put(minicbor::to_vec(info).map_err(ManyError::serialization_error)?),
                 ));
             }
+            self.persistent_store
+                .apply(batch.as_slice())
+                .map_err(error::storage_apply_failed)?;
 
-            batch.push((
-                TOKEN_IDENTITY_ROOT.as_bytes().to_vec(),
-                Op::Put(
-                    token_identity
-                        .unwrap_or(self.get_identity(IDENTITY_ROOT)?)
-                        .to_vec(),
+            let token_identity = token_identity.unwrap_or(self.get_identity(IDENTITY_ROOT)?);
+            let batch: Vec<BatchEntry> = vec![
+                (
+                    key_for_subresource_counter(
+                        &token_identity,
+                        self.migrations.is_active(&TOKEN_MIGRATION),
+                    ),
+                    Op::Put(token_next_subresource.unwrap_or(0).to_be_bytes().to_vec()),
                 ),
-            ));
-            batch.push((
-                TOKEN_SUBRESOURCE_COUNTER_ROOT.as_bytes().to_vec(),
-                Op::Put(token_next_subresource.unwrap_or(0).to_be_bytes().to_vec()),
-            ));
-
+                (
+                    TOKEN_IDENTITY_ROOT.as_bytes().to_vec(),
+                    Op::Put(token_identity.to_vec()),
+                ),
+            ];
             self.persistent_store
                 .apply(batch.as_slice())
                 .map_err(error::storage_apply_failed)?;
@@ -232,8 +237,7 @@ impl LedgerStorage {
         } = args;
 
         // Create a new token symbol and store in memory and in the persistent store
-        let symbol =
-            self.get_next_subresource(TOKEN_IDENTITY_ROOT, TOKEN_SUBRESOURCE_COUNTER_ROOT)?;
+        let symbol = self.get_next_subresource(TOKEN_IDENTITY_ROOT)?;
         self.update_symbols(symbol, summary.ticker.clone())?;
 
         // Initialize the total supply following the initial token distribution, if any

--- a/src/many-ledger/test-utils/Cargo.toml
+++ b/src/many-ledger/test-utils/Cargo.toml
@@ -13,14 +13,14 @@ publish = false
 coset = "0.3"
 cucumber = { version = "0.17.0", features = ["libtest"] }
 itertools = "0.10.3"
-many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["default", "serde", "testing"] }
-many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["ed25519", "ecdsa", "testing"]  }
+many-error = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-identity = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["default", "serde", "testing"] }
+many-identity-dsa = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["ed25519", "ecdsa", "testing"]  }
 many-ledger = { path = "..", features = ["balance_testing"] }
-many-migration = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["cucumber"] }
-many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b" }
-many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "ce03b88dea51232ca578d19d52cfc263cfc4080b", features = ["cucumber"] }
+many-migration = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-modules = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["cucumber"] }
+many-protocol = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801" }
+many-types = { git = "https://github.com/liftedinit/many-rs.git", rev = "0db81ac956bc68c5c43f3f16ede9435ecceb4801", features = ["cucumber"] }
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "3d509c8efd3a68d85a5769f7fff300e10290d137" }
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
 once_cell = "1.12"

--- a/src/many-ledger/test-utils/src/cucumber.rs
+++ b/src/many-ledger/test-utils/src/cucumber.rs
@@ -96,7 +96,7 @@ impl SomeId {
 #[derive(Debug, Default, Eq, Parameter, PartialEq)]
 #[param(
     name = "error",
-    regex = "(unauthorized)|(missing permission)|(immutable)|(invalid sender)|(unable to distribute zero)|(partial burn disabled)|(missing funds)|(over maximum)"
+    regex = "(unauthorized)|(missing permission)|(immutable)|(invalid sender)|(unable to distribute zero)|(partial burn disabled)|(missing funds)|(over maximum)|(ticker exists)"
 )]
 pub enum SomeError {
     #[default]
@@ -108,6 +108,7 @@ pub enum SomeError {
     PartialBurnDisabled,
     MissingFunds,
     OverMaximum,
+    TickerExists,
 }
 
 impl FromStr for SomeError {
@@ -123,6 +124,7 @@ impl FromStr for SomeError {
             "partial burn disabled" => Self::PartialBurnDisabled,
             "missing funds" => Self::MissingFunds,
             "over maximum" => Self::OverMaximum,
+            "ticker exists" => Self::TickerExists,
             _ => unimplemented!(),
         })
     }
@@ -171,6 +173,7 @@ impl SomeError {
             SomeError::PartialBurnDisabled => error::partial_burn_disabled().code(),
             SomeError::MissingFunds => error::missing_funds(Address::anonymous(), "", "").code(),
             SomeError::OverMaximum => error::over_maximum_supply("", "", "").code(),
+            SomeError::TickerExists => error::ticker_exists("").code(),
         }
     }
 }
@@ -301,6 +304,13 @@ where
 
 pub fn verify_error_code<T: LedgerWorld>(w: &mut T, code: ManyErrorCode) {
     assert_eq!(w.error().as_ref().expect("Expecting an error").code(), code);
+}
+
+pub fn verify_error_ticker<T: LedgerWorld>(w: &mut T, ticker: String) {
+    assert_eq!(
+        ticker,
+        w.error().as_ref().unwrap().argument("ticker").unwrap()
+    );
 }
 
 pub fn refresh_token_info<T: LedgerWorld + TokenWorld>(w: &mut T) {

--- a/src/many-ledger/tests/features/ledger_tokens/update_token.feature
+++ b/src/many-ledger/tests/features/ledger_tokens/update_token.feature
@@ -8,6 +8,13 @@ Scenario: Updating a token's ticker as myself
 	Then the token new ticker is ABC
 
 @tokens
+Scenario: Updating a token's ticker as myself, ticker exists
+	Given a default token owned by myself
+	And a new ticker TT
+	Then updating the token as myself fails with ticker exists
+	And the error ticker is TT
+
+@tokens
 Scenario: Updating a token's ticker as myself, with memo
 	Given a default token owned by myself
 	And a new ticker ABC

--- a/src/many-ledger/tests/ledger_tokens/update_token.rs
+++ b/src/many-ledger/tests/ledger_tokens/update_token.rs
@@ -1,7 +1,7 @@
 use many_ledger_test_macros::*;
 use many_ledger_test_utils::cucumber::{
-    verify_error_code, verify_error_role, AccountWorld, LedgerWorld, SomeError, SomeId,
-    SomePermission, TokenWorld,
+    verify_error_code, verify_error_role, verify_error_ticker, AccountWorld, LedgerWorld,
+    SomeError, SomeId, SomePermission, TokenWorld,
 };
 use many_ledger_test_utils::Setup;
 
@@ -172,6 +172,11 @@ fn then_update_token_fail_acl(w: &mut UpdateWorld, id: SomeId, error: SomeError)
 #[then(expr = "the error role is {word}")]
 fn then_error_role(w: &mut UpdateWorld, role: String) {
     verify_error_role(w, role.as_str());
+}
+
+#[then(expr = "the error ticker is {word}")]
+fn error_ticker_is(w: &mut UpdateWorld, ticker: String) {
+    verify_error_ticker(w, ticker);
 }
 
 #[tokio::main]

--- a/tests/e2e/ledger/staging.bats
+++ b/tests/e2e/ledger/staging.bats
@@ -1,0 +1,34 @@
+GIT_ROOT="$BATS_TEST_DIRNAME/../../../"
+MFX_ADDRESS=mqbfbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wiaaaaqnz
+
+load '../../test_helper/load'
+load '../../test_helper/ledger'
+
+function setup() {
+    mkdir "$BATS_TEST_ROOTDIR"
+
+    skip_if_missing_background_utilities
+
+    (
+      cd "$GIT_ROOT"
+      cargo build --features balance_testing
+    )
+
+    cp "$GIT_ROOT/staging/ledger_state.json5" "$BATS_TEST_ROOTDIR/ledger_state.json5"
+    sed -i.bak 's/token_identity: ".*"/token_identity: "'"$(identity 1)"'"/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+    sed -i.bak 's/account_identity: ".*"/account_identity: "'"$(identity 1)"'"/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+}
+
+function teardown() {
+    stop_background_run
+}
+
+@test "$SUITE: Make sure token and account identities are different" {
+    run "$GIT_ROOT/target/debug/many-ledger" \
+        --pem $(pem 1) \
+        -v \
+        --clean \
+        --persistent "ledger.db" \
+        --state "$BATS_TEST_ROOTDIR/ledger_state.json5"
+    assert_output --partial "Token and account identities must be different."
+}

--- a/tests/resiliency/ledger/token_subresource.bats
+++ b/tests/resiliency/ledger/token_subresource.bats
@@ -1,0 +1,181 @@
+# Resiliency test verifying the Token subresource exhaustion
+
+GIT_ROOT="$BATS_TEST_DIRNAME/../../../"
+MAKEFILE="Makefile.ledger"
+MFX_ADDRESS=mqbfbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wiaaaaqnz
+
+load '../../test_helper/load'
+load '../../test_helper/ledger'
+
+function setup() {
+    mkdir "$BATS_TEST_ROOTDIR"
+}
+
+function teardown() {
+    (
+      cd "$GIT_ROOT/docker/e2e/" || exit 1
+      make -f $MAKEFILE stop-nodes
+    ) 2> /dev/null
+
+    # Fix for BATS verbose run/test output gathering
+    cd "$GIT_ROOT/tests/resiliency/ledger" || exit 1
+}
+
+@test "$SUITE: Token subresource exhaustion" {
+    echo '
+    { "migrations": [
+      {
+        "name": "Account Count Data Attribute",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Dummy Hotfix",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Block 9400",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Memo Migration",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Token Migration",
+        "block_height": 20,
+        "token_identity": "'$(identity 1)'",
+        "token_next_subresource": 2147483648,
+        "symbol": "'$(subresource 1 2147483647)'",
+        "symbol_name": "Manifest Network Token",
+        "symbol_decimals": 9,
+        "symbol_total": 100000000000000000,
+        "symbol_circulating": 100000000000000000,
+        "symbol_maximum": null,
+        "symbol_owner": "'$(subresource 1 2147483647)'"
+      }
+    ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
+
+    cp "$GIT_ROOT/staging/ledger_state.json5" "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # The MFX address in the staging file is now `identity 1`
+    sed -i.bak 's/'${MFX_ADDRESS}'/'$(subresource 1 2147483647)'/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Make `identity 1` the token identity
+    sed -i.bak 's/token_identity: ".*"/token_identity: "'"$(identity 1)"'"/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Skip hash check
+    sed -i.bak 's/hash/\/\/hash/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    (
+      cd "$GIT_ROOT/docker/e2e/" || exit
+      make -f $MAKEFILE clean
+      make -f $MAKEFILE $(ciopt start-nodes-dettached) \
+          ABCI_TAG=$(img_tag) \
+          LEDGER_TAG=$(img_tag) \
+          ID_WITH_BALANCES="$(identity 1):1000000:$(subresource 1 2147483647)" \
+          STATE="$BATS_TEST_ROOTDIR/ledger_state.json5" \
+          MIGRATIONS="$BATS_TEST_ROOTDIR/migrations.json" || {
+        echo Could not start nodes... >&3
+        exit 1
+      }
+    ) > /dev/null
+
+    # Give time to the servers to start.
+    sleep 30
+    timeout 30s bash <<EOT
+    while ! many message --server http://localhost:8000 status; do
+      sleep 1
+    done >/dev/null
+EOT
+
+    wait_for_block 20
+
+    call_ledger --pem=1 --port=8000 token create ABC "abc" 9
+    assert_output --partial "Subresources are exhausted"
+}
+
+@test "$SUITE: Token subresource exhaustion, existing subresource" {
+    echo '
+    { "migrations": [
+      {
+        "name": "Account Count Data Attribute",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Dummy Hotfix",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Block 9400",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Memo Migration",
+        "block_height": 0,
+        "disabled": true
+      },
+      {
+        "name": "Token Migration",
+        "block_height": 20,
+        "token_identity": "'$(identity 1)'",
+        "token_next_subresource": 2147483646,
+        "symbol": "'$(subresource 1 2147483647)'",
+        "symbol_name": "Manifest Network Token",
+        "symbol_decimals": 9,
+        "symbol_total": 100000000000000000,
+        "symbol_circulating": 100000000000000000,
+        "symbol_maximum": null,
+        "symbol_owner": "'$(subresource 1 2147483647)'"
+      }
+    ] }' > "$BATS_TEST_ROOTDIR/migrations.json"
+
+    cp "$GIT_ROOT/staging/ledger_state.json5" "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # The MFX address in the staging file is now `identity 1`
+    sed -i.bak 's/'${MFX_ADDRESS}'/'$(subresource 1 2147483647)'/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Make `identity 1` the token identity
+    sed -i.bak 's/token_identity: ".*"/token_identity: "'"$(identity 1)"'"/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Skip hash check
+    sed -i.bak 's/hash/\/\/hash/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    (
+      cd "$GIT_ROOT/docker/e2e/" || exit
+      make -f $MAKEFILE clean
+      make -f $MAKEFILE $(ciopt start-nodes-dettached) \
+          ABCI_TAG=$(img_tag) \
+          LEDGER_TAG=$(img_tag) \
+          ID_WITH_BALANCES="$(identity 1):1000000:$(subresource 1 2147483647)" \
+          STATE="$BATS_TEST_ROOTDIR/ledger_state.json5" \
+          MIGRATIONS="$BATS_TEST_ROOTDIR/migrations.json" || {
+        echo Could not start nodes... >&3
+        exit 1
+      }
+    ) > /dev/null
+
+    # Give time to the servers to start.
+    sleep 30
+    timeout 30s bash <<EOT
+    while ! many message --server http://localhost:8000 status; do
+      sleep 1
+    done >/dev/null
+EOT
+
+    wait_for_block 20
+
+    create_token --pem=1 --port=8000
+    assert_output --partial "$(subresource 1 2147483646)"
+
+    # MFX is subresource 2147483647
+
+    call_ledger --pem=1 --port=8000 token create ABC "abc" 9
+    assert_output --partial "Subresources are exhausted"
+}

--- a/tests/test_helper/many.bash
+++ b/tests/test_helper/many.bash
@@ -37,6 +37,10 @@ function identity() {
     command many id "$(pem "$1")"
 }
 
+function subresource() {
+    command many id "$(pem "$1")" "$2"
+}
+
 function identity_hex() {
     command many id $(many id "$(pem "$1")")
 }


### PR DESCRIPTION
- Refactor subresource storage in DB
- Add a check to prevent updating a token ticker if the ticker already exists on the network
- Add a check to prevent overwriting token subresource already in use
- Add a check to prevent panic if subresources are exhausted
- Add a check making sure `token_identity` and `account_identity` are different 

I added tests covering all those checks.

Depends on https://github.com/liftedinit/many-rs/pull/248